### PR TITLE
Fix setup

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -33,6 +33,8 @@ profiles:
   # prod: pushes images to production with :latest
   - name: prod
     build:
+      local:
+        push: true
       tagPolicy:
         envTemplate:
           template: '{{.IMAGE_NAME}}:latest'

--- a/test/k8s-test-installation.yaml
+++ b/test/k8s-test-installation.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: demo-duct-tape
 spec:
+  restartPolicy: Never
   initContainers:
   - name: init-go
     image: gcr.io/gcp-dev-tools/duct-tape/go


### PR DESCRIPTION
- use `push: true` on the `prod` profile to ensure the results are pushed vs local Minikube
- use `restartPolicy: Never` for the dev testing container as otherwise it just repeats _ad nauseum_ for no useful reason; the container will be restarted when a one of the duct-tape containers change