### PR TITLE
Update go image to dlv 1.3.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.11 as delve
-RUN curl --location --output delve-1.2.0.tar.gz https://github.com/go-delve/delve/archive/v1.2.0.tar.gz \
- && tar xzf delve-1.2.0.tar.gz
-RUN cd delve-1.2.0/cmd/dlv && go install
+FROM golang:1.12 as delve
+RUN curl --location --output delve-1.3.0.tar.gz https://github.com/go-delve/delve/archive/v1.3.0.tar.gz \
+ && tar xzf delve-1.3.0.tar.gz
+RUN cd delve-1.3.0/cmd/dlv && go install
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
Towards GoogleContainerTools/skaffold#2306:
- updates to dlv 1.3.0 (required for debugging go-based containers)
- builds with Go 1.12