### PR TITLE
Update to delve 1.3.1 (actually 1.3.0)

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.12 as delve
-RUN curl --location --output delve-1.3.0.tar.gz https://github.com/go-delve/delve/archive/v1.3.0.tar.gz \
- && tar xzf delve-1.3.0.tar.gz
-RUN cd delve-1.3.0/cmd/dlv && go install
+RUN curl --location --output delve-1.3.1.tar.gz https://github.com/go-delve/delve/archive/v1.3.1.tar.gz \
+ && tar xzf delve-1.3.1.tar.gz
+RUN cd delve-1.3.1/cmd/dlv && go install
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
Delve 1.3.1 was released as 1.3.0 targeted the wrong commit (https://github.com/go-delve/delve/issues/1683).  No functional difference.