### PR TITLE
Update to delve 1.4.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.12 as delve
-RUN curl --location --output delve-1.3.1.tar.gz https://github.com/go-delve/delve/archive/v1.3.1.tar.gz \
- && tar xzf delve-1.3.1.tar.gz
-RUN cd delve-1.3.1/cmd/dlv && go install
+FROM golang:1.14.1 as delve
+RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delve/archive/v1.4.0.tar.gz \
+ && tar xzf delve-1.4.0.tar.gz
+RUN cd delve-1.4.0/cmd/dlv && go install
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
- Update to delve `1.4.0`
    - delve 1.3.1 does not support Go 1.14 and cause a error with Go 1.14 like below:

```
Version of Delve is too old for this version of Go (maximum supported version 1.13, suppress this error with --check-go-version=false)
```