### PR TITLE
Add `node` wrapper and nodejs debug helper image

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.14.1 as delve
 RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delve/archive/v1.4.0.tar.gz \
   && tar xzf delve-1.4.0.tar.gz
 # Produce an as-static-as-possible dlv binary to work on musl and glibc
-RUN cd delve-1.4.0 && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-extldflags "-static"' ./cmd/dlv/
+RUN cd delve-1.4.0 && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-s -w -extldflags "-static"' ./cmd/dlv/
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.14.1 as build
 COPY . .
-ENV GOPATH=
-RUN go build -o node wrapper.go
+# Produce an as-static-as-possible dlv binary to work on musl and glibc
+RUN GOPATH="" CGO_ENABLED=0 go build -o node -ldflags '-s -w -extldflags "-static"' wrapper.go
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.14.1 as build
+COPY . .
+ENV GOPATH=
+RUN go build -o node wrapper.go
+
+# Now populate the duct-tape image with the language runtime debugging support files
+# The debian image is about 95MB bigger
+FROM busybox
+# The install script copies all files in /duct-tape to /dbg
+COPY install.sh /
+CMD ["/bin/sh", "/install.sh"]
+WORKDIR /duct-tape
+COPY --from=build /go/node nodejs/bin/

--- a/nodejs/go.mod
+++ b/nodejs/go.mod
@@ -1,0 +1,8 @@
+module github.com/GoogleContainerTools/container-debug-support/nodejs
+
+go 1.14
+
+require (
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/sirupsen/logrus v1.4.2
+)

--- a/nodejs/go.sum
+++ b/nodejs/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/nodejs/install.sh
+++ b/nodejs/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ ! -d /dbg ]; then
+    echo "Error: installation requires a volume mount at /dbg" 1>&2
+    exit 1
+fi
+
+echo "Installing runtime debugging support files in /dbg"
+tar cf - -C /duct-tape . | tar xf - -C /dbg
+echo "Installation complete"

--- a/nodejs/wrapper.go
+++ b/nodejs/wrapper.go
@@ -80,12 +80,16 @@ func run(nc *nodeContext, stdin io.Reader, stdout, stderr io.Writer) error {
 	}
 	logrus.Debugf("unwrapped: %s\n", nc.program)
 
+	// use an absolute path in case we're being run within a node_modules directory
 	script := findScript(nc.args)
+	if abs, err := filepath.Abs(script); err == nil {
+		script = abs
+	}
 	logrus.Debugf("script: %s\n", script)
 
 	nodeDebugOption, hasNodeDebug := nc.env["NODE_DEBUG"]
 	if hasNodeDebug {
-		logrus.Debugf("NODE_DEBUG: %s", nodeDebugOption)
+		logrus.Debugf("found NODE_DEBUG: %s", nodeDebugOption)
 	}
 
 	// if we're about to execute the application script, install the NODE_DEBUG

--- a/nodejs/wrapper.go
+++ b/nodejs/wrapper.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A wrapper for node executables to support debugging of application scripts.
+// Many NodeJS applications use NodeJS-based launch tools (e.g., npm,
+// nodemon), and often use several in combination.  This makes it very
+// difficult to start debugging the application as `--inspect`s are usually
+// intercepted by one of the launch tools.  When executing a `node_modules`
+// script, this wrapper strips out and propagates `--inspect`-like arguments
+// via `NODE_DEBUG`.  When executing an app script, this wrapper then inlines
+// the `NODE_DEBUG` when found.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	shell "github.com/kballard/go-shellquote"
+	"github.com/sirupsen/logrus"
+)
+
+// nodeContext allows manipulating the launch context for node.
+type nodeContext struct {
+	program string
+	args    []string
+	env     map[string]string
+}
+
+func main() {
+	logrus.SetLevel(logrusLevel())
+
+	nc := nodeContext{program: os.Args[0], args: os.Args[1:], env: envToMap(os.Environ())}
+	if err := run(&nc, os.Stdin, os.Stdout, os.Stderr); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func logrusLevel() logrus.Level {
+	switch os.Getenv("WRAPPER_VERBOSE") {
+	case "trace":
+		return logrus.TraceLevel
+	case "debug":
+		return logrus.DebugLevel
+	case "info":
+		return logrus.InfoLevel
+	case "warn":
+		return logrus.WarnLevel
+	case "error":
+		return logrus.ErrorLevel
+
+	default:
+		return logrus.WarnLevel
+	}
+}
+
+func run(nc *nodeContext, stdin io.Reader, stdout, stderr io.Writer) error {
+	if !nc.unwrap() {
+		return fmt.Errorf("unwrap could not find actual executable")
+	}
+	logrus.Debugf("unwrapped: %s\n", nc.program)
+
+	script := findScript(nc.args)
+	logrus.Debugf("script: %s\n", script)
+
+	nodeDebugOption, hasNodeDebug := nc.env["NODE_DEBUG"]
+	if hasNodeDebug {
+		logrus.Debugf("NODE_DEBUG: %s", nodeDebugOption)
+	}
+
+	// if we're about to execute the application script, install the NODE_DEBUG
+	// arguments if found and go
+	if isApplicationScript(script) {
+		if hasNodeDebug {
+			nc.stripInspectArgs() // top-level debug options win
+			nc.addNodeArg(nodeDebugOption)
+			delete(nc.env, "NODE_DEBUG")
+		}
+		return nc.exec(stdin, stdout, stderr)
+	}
+
+	// We're executing a node module: strip any --inspect args and propagate
+	inspectArg := nc.stripInspectArgs()
+	if inspectArg != "" {
+		logrus.Debugf("Stripped %q as not an app script", inspectArg)
+		if !hasNodeDebug {
+			logrus.Debugf("Setting NODE_DEBUG: %s", inspectArg)
+			nc.env["NODE_DEBUG"] = inspectArg
+		}
+	}
+
+	// nodemon needs special handling as `nodemon --inspect` will use spawn to invoke a
+	// child node, which picks up this wrapped node.  Otherwise nodemon uses fork to launch
+	// the actual application script file directly, which circumvents the use of this node wrapper.
+	nc.handleNodemon()
+
+	return nc.exec(stdin, stdout, stderr)
+}
+
+// unwrap looks for the real node executable (not this wrapper).
+func (nc *nodeContext) unwrap() bool {
+	if nc == nil {
+		return false
+	}
+	path := nc.env["PATH"]
+	origInfo, err := os.Stat(nc.program)
+	origFound := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		logrus.Errorf("unable to stat %q: %v", nc.program, err)
+		return false
+	}
+	base := filepath.Base(nc.program)
+	for _, dir := range strings.Split(path, string(os.PathListSeparator)) {
+		p := filepath.Join(dir, base)
+		if pInfo, err := os.Stat(p); err == nil && (!origFound || !os.SameFile(origInfo, pInfo)) {
+			nc.program = p
+			return true
+		}
+	}
+	logrus.Errorf("unable to unwrap %q: not in PATH", base)
+	return false
+}
+
+// stripInspectArgs removes all `--inspect*` args from both the command-line and from
+// NODE_OPTIONS.  It returns the last inspect arg or "" if there were no inspect arguments.
+func (nc *nodeContext) stripInspectArgs() string {
+	foundOption := ""
+	if options, found := nc.env["NODE_OPTIONS"]; found {
+		if args, err := shell.Split(options); err != nil {
+			logrus.Warnf("NODE_OPTIONS cannot be split: %v", err)
+		} else {
+			args, inspectArg := stripInspectArg(args)
+			if inspectArg != "" {
+				logrus.Debugf("Found %q in NODE_OPTIONS", inspectArg)
+				nc.env["NODE_OPTIONS"] = shell.Join(args...)
+				foundOption = inspectArg
+			}
+		}
+	}
+	strippedArgs, inspectArg := stripInspectArg(nc.args)
+	if inspectArg != "" {
+		logrus.Debugf("Found %q in command-line", inspectArg)
+		nc.args = strippedArgs
+		foundOption = inspectArg
+	}
+	return foundOption
+}
+
+func (nc *nodeContext) handleNodemon() {
+	if nodeDebug, found := nc.env["NODE_DEBUG"]; found {
+		// look for the nodemon script (if it appears) and insert the --inspect argument
+		for i, arg := range nc.args {
+			if len(arg) > 0 && arg[0] != '-' && strings.Contains(arg, "/nodemon") {
+				nc.args = append(nc.args, "")
+				copy(nc.args[i+2:], nc.args[i+1:])
+				nc.args[i+1] = nodeDebug
+				delete(nc.env, "NODE_DEBUG")
+				logrus.Debugf("special handling for nodemon: %q", nc.args)
+				return
+			}
+		}
+	}
+}
+
+func (nc *nodeContext) addNodeArg(nodeArg string) {
+	// find the script location and insert the provided argument
+	if len(nc.args) == 0 {
+		nc.args = []string{nodeArg}
+		return
+	}
+	for i, arg := range nc.args {
+		if len(arg) > 0 && arg[0] != '-' {
+			nc.args = append(nc.args, "")
+			copy(nc.args[i+1:], nc.args[i:])
+			nc.args[i] = nodeArg
+			logrus.Debugf("added node arg: %q", nc.args)
+			return
+		}
+	}
+	nc.args = append(nc.args, nodeArg)
+}
+
+// exec runs the command, and returns an error should one occur.
+func (nc *nodeContext) exec(in io.Reader, out, err io.Writer) error {
+	logrus.Debugf("exec: %s %v (env: %v)", nc.program, nc.args, nc.env)
+	cmd := exec.Command(nc.program, nc.args...)
+	cmd.Env = envFromMap(nc.env)
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = err
+	return cmd.Run()
+}
+
+// findScript returns the path to the node script that will be executed.
+// Returns an empty string if no script was found.
+func findScript(args []string) string {
+	// a bit of a hack, but all node options are of the form `--arg=option`
+	for _, arg := range args {
+		if len(arg) > 0 && arg[0] != '-' {
+			return arg
+		}
+	}
+	return ""
+}
+
+// isApplicationScript return true if the script appears to be an application
+// script, or false if a library (node_modules) script.
+func isApplicationScript(path string) bool {
+	return !strings.HasPrefix(path, "node_modules/") && !strings.Contains(path, "/node_modules/")
+}
+
+// envToMap turns a set of VAR=VALUE strings to a map.
+func envToMap(entries []string) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
+	m := make(map[string]string)
+	for _, entry := range entries {
+		kv := strings.SplitN(entry, "=", 2)
+		m[kv[0]] = kv[1]
+	}
+	return m
+}
+
+// envToMap turns a map of variable:value pairs into a set of VAR=VALUE strings.
+func envFromMap(env map[string]string) []string {
+	var m []string
+	for k, v := range env {
+		m = append(m, k+"="+v)
+	}
+	return m
+}
+
+// stripInspectArg searches and removes all node `--inspect` style arguments, returning the
+// altered arguments and the inspect argument.
+func stripInspectArg(args []string) (newArgs []string, inspectArg string) {
+	// inspect directives are always a single argument: `node --inspect 9226` causes node to load 9226 as a file
+	newArgs = nil
+	inspectArg = "" // default case: no inspect arg found
+
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "--inspect") {
+			// todo: we should coalesce --inspect-port=xxx
+			inspectArg = arg
+			continue
+		}
+
+		// if at end of node options, copy remaining arguments
+		// "--" marks end of node options
+		if arg == "--" || len(arg) == 0 || arg[0] != '-' {
+			newArgs = append(newArgs, args[i:]...)
+			break
+		}
+		newArgs = append(newArgs, arg)
+	}
+	return
+}

--- a/nodejs/wrapper.go
+++ b/nodejs/wrapper.go
@@ -45,8 +45,12 @@ type nodeContext struct {
 
 func main() {
 	logrus.SetLevel(logrusLevel())
+	logrus.Debugf("Launched: %v", os.Args)
 
-	nc := nodeContext{program: os.Args[0], args: os.Args[1:], env: envToMap(os.Environ())}
+	env := envToMap(os.Environ())
+	// suppress npm warnings when node on PATH isn't the node used for npm
+	env["npm_config_scripts_prepend_node_path"] = "false"
+	nc := nodeContext{program: os.Args[0], args: os.Args[1:], env: env}
 	if err := run(&nc, os.Stdin, os.Stdout, os.Stderr); err != nil {
 		logrus.Fatal(err)
 	}

--- a/nodejs/wrapper.go
+++ b/nodejs/wrapper.go
@@ -220,9 +220,11 @@ func findScript(args []string) string {
 }
 
 // isApplicationScript return true if the script appears to be an application
-// script, or false if a library (node_modules) script.
+// script, or false if a library (node_modules) script or `npm` (special case).
 func isApplicationScript(path string) bool {
-	return !strings.HasPrefix(path, "node_modules/") && !strings.Contains(path, "/node_modules/")
+	// We could consider checking if the parent's base name is `bin`?
+	return !strings.HasPrefix(path, "node_modules/") && !strings.Contains(path, "/node_modules/") &&
+		!strings.HasSuffix(path, "/bin/npm")
 }
 
 // envToMap turns a set of VAR=VALUE strings to a map.

--- a/nodejs/wrapper.go
+++ b/nodejs/wrapper.go
@@ -90,7 +90,7 @@ func run(nc *nodeContext, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	// if we're about to execute the application script, install the NODE_DEBUG
 	// arguments if found and go
-	if isApplicationScript(script) {
+	if isApplicationScript(script) || script == "" {
 		if hasNodeDebug {
 			nc.stripInspectArgs() // top-level debug options win
 			nc.addNodeArg(nodeDebugOption)

--- a/nodejs/wrapper_test.go
+++ b/nodejs/wrapper_test.go
@@ -82,6 +82,7 @@ func TestIsApplicationScript(t *testing.T) {
 		expected bool
 	}{
 		{"index.js", true},
+		{"/usr/local/bin/npm", false},
 		{"node_modules/nodemon/nodemon.js", false},
 		{"lib/node_modules/nodemon/nodemon.js", false},
 	}

--- a/nodejs/wrapper_test.go
+++ b/nodejs/wrapper_test.go
@@ -240,37 +240,37 @@ func TestNodeContext_unwrap(t *testing.T) {
 	tests := []struct {
 		description string
 		input       nodeContext
-		result      bool
+		noErr      bool
 		expected    string
 	}{
 		{
 			description: "no PATH leaves unchanged",
 			input:       nodeContext{program: originalNode},
-			result:      false,
+			noErr:      false,
 			expected:    originalNode,
 		},
 		{
 			description: "empty PATH leaves unchanged",
 			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": ""}},
-			result:      false,
+			noErr:      false,
 			expected:    originalNode,
 		},
 		{
 			description: "no other node leaves unchanged",
 			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": root}},
-			result:      false,
+			noErr:      false,
 			expected:    originalNode,
 		},
 		{
 			description: "first other node wins",
 			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": root + string(os.PathListSeparator) + binPath + string(os.PathListSeparator) + sbinPath}},
-			result:      true,
+			noErr:      true,
 			expected:    binNode,
 		},
 		{
 			description: "first node wins when original not found",
 			input:       nodeContext{program: name, env: map[string]string{"PATH": root + string(os.PathListSeparator) + binPath + string(os.PathListSeparator) + sbinPath}},
-			result:      true,
+			noErr:      true,
 			expected:    binNode,
 		},
 	}
@@ -278,9 +278,10 @@ func TestNodeContext_unwrap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			copy := test.input
-			result := copy.unwrap()
-			if result != test.result {
-				t.Errorf("expected unwrap() = %v but got %v", test.result, result)
+			err := copy.unwrap()
+			noErr := err == nil
+			if noErr != test.noErr {
+				t.Errorf("unexpected unwrap() error return: %q", err)
 			}
 			if copy.program != test.expected {
 				t.Errorf("expected %v but got %v", test.expected, copy.program)

--- a/nodejs/wrapper_test.go
+++ b/nodejs/wrapper_test.go
@@ -1,0 +1,548 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestFindScript(t *testing.T) {
+	tests := []struct {
+		description string
+		args        []string
+		expected    string
+	}{
+		{
+			description: "no args",
+			args:        []string{},
+			expected:    "",
+		},
+		{
+			description: "single script",
+			args:        []string{"index.js"},
+			expected:    "index.js",
+		},
+		{
+			description: "options but no script",
+			args:        []string{"-i", "--help"},
+			expected:    "",
+		},
+		{
+			description: "options and script",
+			args:        []string{"-i", "--help", "index.js"},
+			expected:    "index.js",
+		},
+		{
+			description: "options, script, and arguments",
+			args:        []string{"-i", "--help", "index.js", "arg1", "arg2"},
+			expected:    "index.js",
+		},
+		{
+			description: "options, script path, and arguments",
+			args:        []string{"-i", "--help", "node_modules/index.js", "arg1", "arg2"},
+			expected:    "node_modules/index.js",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := findScript(test.args)
+			if result != test.expected {
+				t.Errorf("expected %s but got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsApplicationScript(t *testing.T) {
+	tests := []struct {
+		script   string
+		expected bool
+	}{
+		{"index.js", true},
+		{"node_modules/nodemon/nodemon.js", false},
+		{"lib/node_modules/nodemon/nodemon.js", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.script, func(t *testing.T) {
+			result := isApplicationScript(test.script)
+			if result != test.expected {
+				t.Errorf("expected %v but got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestEnvFromMap(t *testing.T) {
+	tests := []struct {
+		description string
+		env         map[string]string
+		expected    []string
+	}{
+		{"nil", nil, nil},
+		{"empty", map[string]string{}, nil},
+		{"single", map[string]string{"a": "b"}, []string{"a=b"}},
+		{"multiple", map[string]string{"a": "b", "c": "d"}, []string{"a=b", "c=d"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := envFromMap(test.env)
+			sort.Strings(result)
+			if len(result) != len(test.expected) {
+				t.Errorf("expected %v but got %v", test.expected, result)
+			} else {
+				for i := 0; i < len(result); i++ {
+					if result[i] != test.expected[i] {
+						t.Errorf("expected %v but got %v", test.expected[i], result[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEnvToMap(t *testing.T) {
+	tests := []struct {
+		description string
+		env         []string
+		expected    map[string]string
+	}{
+		{"nil", nil, nil},
+		{"empty", []string{}, nil},
+		{"single", []string{"a=b"}, map[string]string{"a": "b"}},
+		{"multiple", []string{"a=b", "c=d"}, map[string]string{"a": "b", "c": "d"}},
+		{"collisions", []string{"a=b", "a=d"}, map[string]string{"a": "d"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := envToMap(test.env)
+			if len(result) != len(test.expected) {
+				t.Errorf("expected %v but got %v", test.expected, result)
+			} else {
+				for k, v := range result {
+					if v != test.expected[k] {
+						t.Errorf("for %v expected %v but got %v", k, test.expected[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStripInspectArg(t *testing.T) {
+	tests := []struct {
+		description string
+		args        []string
+		newArgs     []string
+		inspectArg  string
+	}{
+		{"nil", nil, nil, ""},
+		{"no args", []string{}, []string{}, ""},
+		{"no inspect args", []string{"--foo", "bar"}, []string{"--foo", "bar"}, ""},
+		{"lone <<<INSPECT>>> removed", []string{"<<<INSPECT>>>"}, []string{}, "<<<INSPECT>>>"},
+		{"<<<INSPECT>>> at beginning removed", []string{"<<<INSPECT>>>", "--foo", "bar"}, []string{"--foo", "bar"}, "<<<INSPECT>>>"},
+		{"<<<INSPECT>>> mid way removed", []string{"-c", "<<<INSPECT>>>", "--foo", "bar"}, []string{"-c", "--foo", "bar"}, "<<<INSPECT>>>"},
+		{"<<<INSPECT>>> after script untouched", []string{"--foo", "bar", "<<<INSPECT>>>"}, []string{"--foo", "bar", "<<<INSPECT>>>"}, ""},
+	}
+
+	for _, test := range tests {
+		// run the test for the difference inspect variants
+		for _, inspect := range []string{"--inspect", "--inspect=9224", "--inspect-brk", "--inspect-brk=3452"} {
+			test.description = strings.ReplaceAll(test.description, "<<<INSPECT>>>", inspect)
+			for i := range test.args {
+				if test.args[i] == "<<<INSPECT>>>" {
+					test.args[i] = inspect
+				}
+			}
+			for i := range test.newArgs {
+				if test.newArgs[i] == "<<<INSPECT>>>" {
+					test.newArgs[i] = inspect
+				}
+			}
+			if test.inspectArg == "<<<INSPECT>>>" {
+				test.inspectArg = inspect
+			}
+		}
+		t.Run(test.description, func(t *testing.T) {
+			newArgs, inspectArg := stripInspectArg(test.args)
+			if len(newArgs) != len(test.newArgs) {
+				t.Errorf("expected %v but got %v", test.newArgs, newArgs)
+			} else {
+				for i := 0; i < len(newArgs); i++ {
+					if newArgs[i] != test.newArgs[i] {
+						t.Errorf("expected %v but got %v", test.newArgs[i], newArgs[i])
+					}
+				}
+			}
+			if inspectArg != test.inspectArg {
+				t.Errorf("expected %v but got %v", test.inspectArg, inspectArg)
+			}
+		})
+	}
+}
+
+func TestNodeContext_unwrap(t *testing.T) {
+	name := "foo" // ensure no code explicitly looks for "node"
+
+	root, err := ioutil.TempDir("", "nc")
+	if err != nil {
+		t.Error(err)
+	}
+	originalNode := filepath.Join(root, name)
+	if err := ioutil.WriteFile(originalNode, []byte{}, 0555); err != nil {
+		t.Error(err)
+	}
+	binPath := filepath.Join(root, "bin")
+	if err := os.Mkdir(binPath, 0777); err != nil {
+		t.Error(err)
+	}
+	binNode := filepath.Join(binPath, name)
+	if err := ioutil.WriteFile(binNode, []byte{}, 0555); err != nil {
+		t.Error(err)
+	}
+	sbinPath := filepath.Join(root, "sbin")
+	if err := os.Mkdir(sbinPath, 0777); err != nil {
+		t.Error(err)
+	}
+	sbinNode := filepath.Join(sbinPath, name)
+	if err := ioutil.WriteFile(sbinNode, []byte{}, 0555); err != nil {
+		t.Error(err)
+	}
+
+	t.Cleanup(func() { os.RemoveAll(root) })
+
+	tests := []struct {
+		description string
+		input       nodeContext
+		result      bool
+		expected    string
+	}{
+		{
+			description: "no PATH leaves unchanged",
+			input:       nodeContext{program: originalNode},
+			result:      false,
+			expected:    originalNode,
+		},
+		{
+			description: "empty PATH leaves unchanged",
+			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": ""}},
+			result:      false,
+			expected:    originalNode,
+		},
+		{
+			description: "no other node leaves unchanged",
+			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": root}},
+			result:      false,
+			expected:    originalNode,
+		},
+		{
+			description: "first other node wins",
+			input:       nodeContext{program: originalNode, env: map[string]string{"PATH": root + string(os.PathListSeparator) + binPath + string(os.PathListSeparator) + sbinPath}},
+			result:      true,
+			expected:    binNode,
+		},
+		{
+			description: "first node wins when original not found",
+			input:       nodeContext{program: name, env: map[string]string{"PATH": root + string(os.PathListSeparator) + binPath + string(os.PathListSeparator) + sbinPath}},
+			result:      true,
+			expected:    originalNode,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			copy := test.input
+			result := copy.unwrap()
+			if result != test.result {
+				t.Errorf("expected unwrap() = %v but got %v", test.result, result)
+			}
+			if copy.program != test.expected {
+				t.Errorf("expected %v but got %v", test.expected, copy.program)
+			}
+		})
+	}
+}
+
+func TestNodeContext_StripInspectArgs(t *testing.T) {
+	tests := []struct {
+		description string
+		input       nodeContext
+		expected    nodeContext
+		arg         string
+	}{
+		{
+			description: "no inspect",
+			input:       nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io"}},
+			arg:         "",
+		},
+		{
+			description: "inspect in args",
+			input:       nodeContext{args: []string{"--inspect", "--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io"}},
+			arg:         "--inspect",
+		},
+		{
+			description: "inspect in NODE_OPTIONS",
+			input:       nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io --inspect-brk"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_OPTIONS": "--trace-sync-io"}},
+			arg:         "--inspect-brk",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			copy := test.input
+			arg := copy.stripInspectArgs()
+			if arg != test.arg {
+				t.Errorf("expected inspect args = %v but got %v", test.arg, arg)
+			}
+			if !reflect.DeepEqual(copy, test.expected) {
+				t.Errorf("expected %v but got %v", test.expected, copy)
+			}
+		})
+	}
+}
+
+func TestNodeContext_HandleNodemon(t *testing.T) {
+	tests := []struct {
+		description string
+		input       nodeContext
+		expected    nodeContext
+	}{
+		{
+			description: "no nodemon",
+			input:       nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_DEBUG": "--inspect=3333"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "index.js"}, env: map[string]string{"NODE_DEBUG": "--inspect=3333"}},
+		},
+		{
+			description: "nodemon no args",
+			input:       nodeContext{args: []string{"--no-warnings", "./node_modules/nodemon/bin/nodemon.js"}, env: map[string]string{"NODE_DEBUG": "--inspect=3333"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "./node_modules/nodemon/bin/nodemon.js", "--inspect=3333"}, env: map[string]string{}},
+		},
+		{
+			description: "nodemon with args",
+			input:       nodeContext{args: []string{"--no-warnings", "./node_modules/nodemon/bin/nodemon.js", "-v", "index.js"}, env: map[string]string{"NODE_DEBUG": "--inspect=3333"}},
+			expected:    nodeContext{args: []string{"--no-warnings", "./node_modules/nodemon/bin/nodemon.js", "--inspect=3333", "-v", "index.js"}, env: map[string]string{}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			copy := test.input
+			copy.handleNodemon()
+			if !reflect.DeepEqual(copy, test.expected) {
+				t.Errorf("mismatch\nexpected: %v\n but got: %v", test.expected, copy)
+			}
+		})
+	}
+}
+
+func TestNodeContext_AddNodeArg(t *testing.T) {
+	tests := []struct {
+		description string
+		input       nodeContext
+		arg         string
+		expected    nodeContext
+	}{
+		{
+			description: "nil args",
+			input:       nodeContext{},
+			arg:         "abc",
+			expected:    nodeContext{args: []string{"abc"}},
+		},
+		{
+			description: "no script",
+			input:       nodeContext{args: []string{"--no-warnings"}},
+			arg:         "abc",
+			expected:    nodeContext{args: []string{"--no-warnings", "abc"}},
+		},
+		{
+			description: "after options before script",
+			input:       nodeContext{args: []string{"--no-warnings", "index.js"}},
+			arg:         "abc",
+			expected:    nodeContext{args: []string{"--no-warnings", "abc", "index.js"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			copy := test.input
+			copy.addNodeArg(test.arg)
+			if !reflect.DeepEqual(copy, test.expected) {
+				t.Errorf("expected %v but got %v", test.expected, copy)
+			}
+		})
+	}
+}
+
+func TestIntegration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("we only support nix")
+	}
+	root, err := ioutil.TempDir("", "node")
+	if err != nil {
+		t.Error(err)
+	}
+
+	actualNode := filepath.Join(root, "nodeBin")
+	script := `#!/bin/sh
+if [ -n "$NODE_DEBUG" ]; then
+  echo "NODE_DEBUG=$NODE_DEBUG"
+fi
+if [ -n "$NODE_OPTIONS" ]; then
+  echo "NODE_OPTIONS=$NODE_OPTIONS"
+fi
+for arg in "$@"; do
+  echo "$arg"
+done
+`
+	if err := ioutil.WriteFile(actualNode, []byte(script), 0555); err != nil {
+		t.Errorf("could not create node script: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(root) })
+
+	tests := []struct {
+		description string
+		args        []string
+		env         map[string]string
+		expected    string
+	}{
+		// app scripts are terminal: commands should only affected if NODE_DEBUG is defined
+		{
+			description: "app script: passed through",
+			args:        []string{"script.js"},
+			expected:    "script.js\n",
+		},
+		{
+			description: "app script: inspect arg passed through",
+			args:        []string{"--inspect", "script.js"},
+			expected:    "--inspect\nscript.js\n",
+		},
+		{
+			description: "app script: inspect as app args left alone",
+			args:        []string{"script.js", "--inspect"},
+			expected:    "script.js\n--inspect\n",
+		},
+		{
+			description: "app script with NODE_OPTIONS='--inspect': passed through",
+			args:        []string{"script.js"},
+			env:         map[string]string{"NODE_OPTIONS": "--inspect"},
+			expected:    "NODE_OPTIONS=--inspect\nscript.js\n",
+		},
+		{
+			description: "app script with NODE_OPTIONS='--foo --inspect --bar': passed through",
+			args:        []string{"script.js"},
+			env:         map[string]string{"NODE_OPTIONS": "--foo --inspect --bar"},
+			expected:    "NODE_OPTIONS=--foo --inspect --bar\nscript.js\n",
+		},
+		{
+			description: "app script with NODE_DEBUG='--inspect': installed",
+			args:        []string{"script.js"},
+			env:         map[string]string{"NODE_DEBUG": "--inspect"},
+			expected:    "--inspect\nscript.js\n",
+		},
+
+		// node_module scripts should have --inspect stripped and propagated,
+		// and NODE_DEBUG should never be overwritten
+		{
+			description: "node_modules script: passed through",
+			args:        []string{"node_modules/script.js"},
+			expected:    "node_modules/script.js\n",
+		},
+		{
+			description: "node_modules script: inspect as app args left alone",
+			args:        []string{"node_modules/script.js", "--inspect"},
+			expected:    "node_modules/script.js\n--inspect\n",
+		},
+		{
+			description: "node_modules script with inspect: seeds NODE_DEBUG",
+			args:        []string{"--inspect", "node_modules/script.js"},
+			expected:    "NODE_DEBUG=--inspect\nnode_modules/script.js\n",
+		},
+		{
+			description: "node_modules script with NODE_OPTIONS='--inspect': seeds NODE_DEBUG",
+			args:        []string{"node_modules/script.js"},
+			env:         map[string]string{"NODE_OPTIONS": "--inspect"},
+			expected:    "NODE_DEBUG=--inspect\nnode_modules/script.js\n",
+		},
+		{
+			description: "node_modules script with NODE_OPTIONS='--foo --inspect --bar': seeds NODE_DEBUG",
+			args:        []string{"node_modules/script.js"},
+			env:         map[string]string{"NODE_OPTIONS": "--foo --inspect --bar"},
+			expected:    "NODE_DEBUG=--inspect\nNODE_OPTIONS=--foo --bar\nnode_modules/script.js\n",
+		},
+		{
+			description: "node_modules script with NODE_DEBUG='--inspect': passed through",
+			args:        []string{"node_modules/script.js"},
+			env:         map[string]string{"NODE_DEBUG": "--inspect"},
+			expected:    "NODE_DEBUG=--inspect\nnode_modules/script.js\n",
+		},
+		{
+			description: "node_modules script with NODE_DEBUG='--inspect' and inspect-brk arg: NODE_DEBUG wins",
+			args:        []string{"--inspect-brk", "node_modules/script.js"},
+			env:         map[string]string{"NODE_DEBUG": "--inspect"},
+			expected:    "NODE_DEBUG=--inspect\nnode_modules/script.js\n",
+		},
+		{
+			description: "node_modules script with NODE_DEBUG='--inspect' and inspect-brk NODE_OPTIONS: NODE_DEBUG wins",
+			args:        []string{"node_modules/script.js"},
+			env:         map[string]string{"NODE_DEBUG": "--inspect", "NODE_OPTIONS": "--inspect-brk"},
+			expected:    "NODE_DEBUG=--inspect\nnode_modules/script.js\n",
+		},
+		{
+			description: "nodemon script with NODE_DEBUG='--inspect': added to nodemon",
+			args:        []string{"node_modules/nodemon/nodemon.js"},
+			env:         map[string]string{"NODE_DEBUG": "--inspect"},
+			expected:    "node_modules/nodemon/nodemon.js\n--inspect\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			env := map[string]string{"PATH": root + string(os.PathListSeparator) + os.Getenv("PATH")}
+			for k, v := range test.env {
+				env[k] = v
+			}
+
+			nc := nodeContext{program: "nodeBin", args: test.args, env: env}
+			var in bytes.Buffer
+			var out bytes.Buffer
+			if err := run(&nc, &in, &out, &out); err != nil {
+				t.Errorf("node exec failed: %v", err)
+			}
+			if nc.program != actualNode {
+				t.Errorf("unwrap resolved to %q but wanted %q", nc.program, actualNode)
+			}
+			if out.String() != test.expected {
+				t.Errorf("output mismatch\nexpected: %q\n but got: %q", test.expected, out.String())
+			}
+		})
+	}
+
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,6 +8,8 @@ build:
     context: python
   - image: gcr.io/gcp-dev-tools/duct-tape/netcore
     context: netcore
+  - image: gcr.io/gcp-dev-tools/duct-tape/nodejs
+    context: nodejs
 test:
   - image: gcr.io/gcp-dev-tools/duct-tape/go
     structureTests: [./test/structure-tests-go.yaml]
@@ -15,6 +17,8 @@ test:
     structureTests: [./test/structure-tests-python.yaml]
   - image: gcr.io/gcp-dev-tools/duct-tape/netcore
     structureTests: [./test/structure-tests-netcore.yaml]
+  - image: gcr.io/gcp-dev-tools/duct-tape/nodejs
+    structureTests: [./test/structure-tests-nodejs.yaml]
 deploy:
   kubectl:
     manifests:

--- a/test/k8s-test-installation.yaml
+++ b/test/k8s-test-installation.yaml
@@ -22,6 +22,11 @@ spec:
     volumeMounts:
     - name: dbg
       mountPath: "/dbg"
+  - name: init-nodejs
+    image: gcr.io/gcp-dev-tools/duct-tape/nodejs
+    volumeMounts:
+    - name: dbg
+      mountPath: "/dbg"
   containers:
   - name: ls-dbg
     image: busybox

--- a/test/structure-tests-nodejs.yaml
+++ b/test/structure-tests-nodejs.yaml
@@ -1,0 +1,18 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: 'node wrapper'
+    path: '/duct-tape/nodejs/bin/node'
+
+commandTests:
+  - name: "run with no /dbg should fail"
+    command: "sh"
+    args: ["/install.sh"]
+    expectedError: ["Error: installation requires a volume mount at /dbg"]
+    exitCode: 1
+  - name: "run with /dbg should install"
+    setup: [["mkdir", "/dbg"]]
+    command: "sh"
+    args: ["/install.sh"]
+    expectedOutput: ["Installing runtime debugging support files in /dbg", "Installation complete"]
+    exitCode: 0


### PR DESCRIPTION
This PR:
  1. Introduces a _node wrapper_ that has special handling to ensure for `--inspect`-style arguments are only used when running application scripts.
  2. Creates a new `nodejs` debug helper image that installs this `node` wrapper.

Towards fixing GoogleContainerTools/skaffold#2170.  With this `nodejs` debug helper image in place, we can then change `skaffold debug` to 1) use the debug helper image, and 2) set PATH to cause this node-wrapper to be invoked.

----

NodeJS's `node` supports a set of `--inspect` arguments to activate debugging mode using the Chrome DevTools protocol.  There are a few variants:

  - `--inspect` or `--inspect=<port>`: launches the app with devtools listening on the given port (or default 9229)
  - `--inspect-brk` or `--inspect-brk=<port>`: launches but immediately stops the app

Many NodeJS applications use NodeJS-based tools like `npm` and `nodemon` to launch the app rather than running `node` directly, and often use several layered together.  For example, Skaffold's own [`nodejs` example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/nodejs/backend) uses npm invoking nodemon, which then invokes node.  Further complicating the issue is that the `node` images on Docker Hub use `docker-entrypoint.sh` as a helper script for launching apps.  So this example might cause the following sequence:

  1. `docker-entrypoint.sh sh -c 'npm run production'`
  2. `npm run production`
  3. `node /path/to/npm run production`
  4. `node src/index.js`

This sequence makes it very difficult for `skaffold debug` to start launch the application for debugging as `--inspect`s are usually intercepted by one of the launch tools.

This PR provides a _node wrapper_ that adds special handling for `--inspect`-style arguments on the command-line and `NODE_OPTIONS` environment variable.  When executing a `node_modules` script, any `--inspect`-like arguments are stripped and put in `NODE_DEBUG`.  When executing an application script (i.e., does not live in `node_modules`), the `NODE_DEBUG` value is inlined.

For example, `skaffold debug -p dev` on `nodejs` example would do the following:
  1. run `docker-entrypoint.sh sh -c 'npm run production'` with `NODE_OPTIONS=--inspect=9229` but with `PATH=/path/to/this/wrapper:$PATH`
  2. `npm run production` (with `NODE_OPTIONS=--inspect=9229`)
  3. `/path/to/this/wrapper/node /path/to/npm run production` — `npm` is recognized as a non-application script and thus  the `--inspect=9229` is stripped from the `NODE_OPTIONS` and placed it in `NODE_DEBUG`
  3. `/path/to/actual/node /path/to/npm run production`
  4. `/path/to/this/wrapper/node src/index.js` — `src/index.js` is recognized as an application script and so `NODE_DEBUG` is inlined to the `node` command-line
  6. `/path/to/actual/node --inspect=9229 src/index.js`

----

If you have npm/node on your system, you can check it out with something as simple as:
```
$ cd nodejs/
$ go build -o node .
$ cat package.json
{
  "name": "backend",
  "version": "1.0.0",
  "scripts": {
    "production": "node index.js",
    "development": "nodemon index.js"
  },
  "devDependencies": {
    "nodemon": "^1.18.4"
  }
}

$ cat index.js
console.log("Hello, World!");

$ NODE_OPTIONS=--inspect npm install
Debugger listening on ws://127.0.0.1:9229/16fad1a5-3de7-4813-9512-31f94caa3090
For help, see: https://nodejs.org/en/docs/inspector
...
$ NODE_OPTIONS=--inspect npm run production
Debugger listening on ws://127.0.0.1:9229/4f066a67-b682-4997-b887-8ac77fda1f3b
For help, see: https://nodejs.org/en/docs/inspector

> backend@1.0.0 production /app
> node index.js

Starting inspector on 127.0.0.1:9229 failed: address already in use
...
```

Whereas with the node-wrapper in place:

```console
$ NODE_OPTIONS=--inspect PATH=.:$PATH WRAPPER_VERBOSE=debug npm install
...
$ NODE_OPTIONS=--inspect PATH=.:$PATH WRAPPER_VERBOSE=debug npm run production
...
DEBU[0000] exec: /usr/local/bin/node [/usr/local/bin/npm run production] (env: map[HOME:/root  NODE_DEBUG:--inspect NODE_OPTIONS: PATH:/n:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin  WRAPPER_VERBOSE:debug _:/usr/local/bin/npm npm_config_scripts_prepend_node_path:false]) 

> backend@1.0.0 production /app
> node index.js

...
DEBU[0000] exec: /usr/local/bin/node [--inspect index.js] (env: map[HOME:/root HOSTNAME:401afbcac003 INIT_CWD:/app NODE:/usr/local/bin/node NODE_OPTIONS: WRAPPER_VERBOSE:debug)
...
Debugger listening on ws://127.0.0.1:9229/614eb2cc-8f39-4bc2-a780-8109931cb134
For help, see: https://nodejs.org/en/docs/inspector
Hello, World!
```


To see it in action, we use [Skaffold's simple NodeJS project](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/nodejs/backend) with `npm` and the `node` image:
```console
$ cd nodejs
$ GOOS=linux go build -o node .
$ cd $skaffold/examples/nodejs/backend
$ docker build -t nodejs-example .
$ docker run -it --rm -v $OLDPWD:/n \
   -v $PWD:/home/node/app \
   -w /home/node/app \
   -e 'PATH=/n:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
   -e WRAPPER_VERBOSE=debug \
   -e NODE_OPTIONS=--inspect \
   nodejs-example \
   npm run production
```
