### PR TITLE
Revert dlv to 1.3.1

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.14.1 as delve
-RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delve/archive/v1.4.0.tar.gz \
-  && tar xzf delve-1.4.0.tar.gz
+RUN curl --location --output delve-1.3.1.tar.gz https://github.com/go-delve/delve/archive/v1.3.1.tar.gz \
+  && tar xzf delve-1.3.1.tar.gz
 # Produce an as-static-as-possible dlv binary to work on musl and glibc
-RUN cd delve-1.4.0 && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-extldflags "-static"' ./cmd/dlv/
+RUN cd delve-1.3.1 && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-extldflags "-static"' ./cmd/dlv/
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
#33 upgraded Delve to v1.14.  Delve 1.14 introduces a new behaviour to enforce that when listening for connections are from the same user (https://github.com/go-delve/delve/pull/1764).  This behaviour is enabled by default and breaks current uses of `skaffold debug` as the connections proxied via kubectl are local but from a different user.

**Steps to reproduce**: 

Use `skaffold debug` on Skaffold's [Getting Started](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/getting-started) example.  The container will seem to start with no issue, but attempting to connect will fail:
```
$ dlv connect 127.0.0.1:56268
Type 'help' for list of commands.
(dlv) bt
Command failed: connection is shut down
(dlv) c
Command failed: connection is shut down
(dlv) exit
connection is shut down
```

**Log output**: <!-- If applicable, provide relevant log output -->

When enabling Delve's logging on the server (in the container):
```
[web-5f64f88986-nwl74 install-go-support] Installing runtime debugging support files in /dbg
[web-5f64f88986-nwl74 install-go-support] Installation complete
[web-5f64f88986-nwl74 web] API server listening at: 127.0.0.1:56268
[web-5f64f88986-nwl74 web] 2020-04-25T20:59:37Z info layer=debugger launching process with args: [/layers/google.go.build/bin/main]
[web-5f64f88986-nwl74 web] 2020-04-25T20:59:37Z debug layer=debugger continuing
[web-5f64f88986-nwl74 web] 2020/04/25 20:59:37 Listening on port :8080
[web-5f64f88986-nwl74 web] 2020/04/25 20:59:58 sameuser_linux.go:111: closing connection from different user (127.0.0.1:47726): connections to localhost are only accepted from the same UNIX user for security reasons
```

**Additional Information**: 

We can work around this by having Delve listen on `0.0.0.0` rather than localhost, but as this breaks installations in the field, we need to revert to Delve 1.3.1 first.