### PR TITLE
Update to delve 1.4.1

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.14.1 as delve
+FROM golang:1.14.3 as delve
 
-RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delve/archive/v1.4.0.tar.gz \
-  && tar xzf delve-1.4.0.tar.gz \
-  && mv delve-1.4.0 delve-source
+ARG DELVE_VERSION=1.4.1
+
+RUN curl --location --output delve-$DELVE_VERSION.tar.gz https://github.com/go-delve/delve/archive/v$DELVE_VERSION.tar.gz \
+  && tar xzf delve-$DELVE_VERSION.tar.gz \
+  && mv delve-$DELVE_VERSION delve-source
 
 # Patch delve to change default for --only-same-user to false
 # Required as `kubectl port-forward` to dlv port is refused.

--- a/go/delve-only-same-user.patch
+++ b/go/delve-only-same-user.patch
@@ -7,11 +7,11 @@ the outside of the pod, and so connecting to the dlv port is refused.
 --- cmd/dlv/cmds/commands.go
 +++ cmd/dlv/cmds/commands.go
 @@ -114,7 +114,7 @@ func New(docCall bool) *cobra.Command {
- 	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
- 	RootCommand.PersistentFlags().StringVar(&WorkingDir, "wd", ".", "Working directory for running the program.")
- 	RootCommand.PersistentFlags().BoolVarP(&CheckGoVersion, "check-go-version", "", true, "Checks that the version of Go in use is compatible with Delve.")
--	RootCommand.PersistentFlags().BoolVarP(&CheckLocalConnUser, "only-same-user", "", true, "Only connections from the same user that started this instance of Delve are allowed to connect.")
-+	RootCommand.PersistentFlags().BoolVarP(&CheckLocalConnUser, "only-same-user", "", false, "Only connections from the same user that started this instance of Delve are allowed to connect.")
- 	RootCommand.PersistentFlags().StringVar(&Backend, "backend", "default", `Backend selection (see 'dlv help backend').`)
- 
+ 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
+ 	rootCommand.PersistentFlags().StringVar(&workingDir, "wd", ".", "Working directory for running the program.")
+ 	rootCommand.PersistentFlags().BoolVarP(&checkGoVersion, "check-go-version", "", true, "Checks that the version of Go in use is compatible with Delve.")
+-	rootCommand.PersistentFlags().BoolVarP(&checkLocalConnUser, "only-same-user", "", true, "Only connections from the same user that started this instance of Delve are allowed to connect.")
++	rootCommand.PersistentFlags().BoolVarP(&checkLocalConnUser, "only-same-user", "", false, "Only connections from the same user that started this instance of Delve are allowed to connect.")
+ 	rootCommand.PersistentFlags().StringVar(&backend, "backend", "default", `Backend selection (see 'dlv help backend').`)
+
  	// 'attach' subcommand.


### PR DESCRIPTION
- Update to delve 1.4.1.
    - https://github.com/go-delve/delve/releases/tag/v1.4.1
- Update builder image to golang:1.14.3.