### PR TITLE
Simplify updating Go/Delve image

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.14.1 as delve
 
 RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delve/archive/v1.4.0.tar.gz \
-  && tar xzf delve-1.4.0.tar.gz
+  && tar xzf delve-1.4.0.tar.gz \
+  && mv delve-1.4.0 delve-source
 
 # Patch delve to change default for --only-same-user to false
 # Required as `kubectl port-forward` to dlv port is refused.
@@ -9,10 +10,10 @@ RUN curl --location --output delve-1.4.0.tar.gz https://github.com/go-delve/delv
 COPY delve-only-same-user.patch .
 RUN apt-get update && apt-get install -y --no-install-recommends \
   patch \
-  && patch -p0 < delve-only-same-user.patch
+  && patch -p0 -d delve-source < delve-only-same-user.patch
 
 # Produce an as-static-as-possible dlv binary to work on musl and glibc
-RUN cd delve-1.4.0 && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-s -w -extldflags "-static"' ./cmd/dlv/
+RUN cd delve-source && CGO_ENABLED=0 go build -o /go/dlv -ldflags '-s -w -extldflags "-static"' ./cmd/dlv/
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger

--- a/go/delve-only-same-user.patch
+++ b/go/delve-only-same-user.patch
@@ -1,7 +1,11 @@
-diff --git delve-1.4.0/cmd/dlv/cmds/commands.go delve-1.4.0/cmd/dlv/cmds/commands.go
-index 0a17860..7e46206 100644
---- delve-1.4.0/cmd/dlv/cmds/commands.go
-+++ delve-1.4.0/cmd/dlv/cmds/commands.go
+Patch delve to default --only-same-user to false [1].
+Required as connections proxied via `kubectl port-forward` come from
+the outside of the pod, and so connecting to the dlv port is refused.
+
+[1] https://github.com/go-delve/delve/pull/1764
+
+--- cmd/dlv/cmds/commands.go
++++ cmd/dlv/cmds/commands.go
 @@ -114,7 +114,7 @@ func New(docCall bool) *cobra.Command {
  	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
  	RootCommand.PersistentFlags().StringVar(&WorkingDir, "wd", ".", "Working directory for running the program.")


### PR DESCRIPTION
Updating the Go image for a new version of Delve (like in #39) is harder than it should be as the Delve version is featured in several places in the Dockerfile and in the Delve patch introduced in #38.

This patch renamed the Delve extraction point to remove the version string, and removes the version from the patch.  It also adds some additional context for the patch.