### PR TITLE
Ensure built images are tagged with :latest

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,6 +10,9 @@ build:
     context: netcore
   - image: gcr.io/gcp-dev-tools/duct-tape/nodejs
     context: nodejs
+  # ensure images are tagged with :latest
+  tagPolicy:
+    sha256: {}
 test:
   - image: gcr.io/gcp-dev-tools/duct-tape/go
     structureTests: [./test/structure-tests-go.yaml]
@@ -67,6 +70,3 @@ profiles:
     build:
       local:
         push: true
-      tagPolicy:
-        envTemplate:
-          template: '{{.IMAGE_NAME}}:latest'


### PR DESCRIPTION
Ensure images are tagged with `latest`.  This is necessary to allow users to build and reference their own copies.