### PR TITLE
Install debugpy and add support for Python 3.9

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,11 +1,14 @@
 FROM python:2.7 as python27
-RUN PYTHONUSERBASE=/ptvsd pip install --user ptvsd
+RUN PYTHONUSERBASE=/dbgpy pip install --user ptvsd debugpy
 
 FROM python:3.7 as python37
-RUN PYTHONUSERBASE=/ptvsd pip install --user ptvsd
+RUN PYTHONUSERBASE=/dbgpy pip install --user ptvsd debugpy
 
 FROM python:3.8 as python38
-RUN PYTHONUSERBASE=/ptvsd pip install --user ptvsd
+RUN PYTHONUSERBASE=/dbgpy pip install --user ptvsd debugpy
+
+FROM python:3.9 as python39
+RUN PYTHONUSERBASE=/dbgpy pip install --user ptvsd debugpy
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
@@ -14,6 +17,7 @@ FROM busybox
 COPY install.sh /
 CMD ["/bin/sh", "/install.sh"]
 WORKDIR /duct-tape
-COPY --from=python27 /ptvsd/ python/
-COPY --from=python37 /ptvsd/ python/
-COPY --from=python38 /ptvsd/ python/
+COPY --from=python27 /dbgpy/ python/
+COPY --from=python37 /dbgpy/ python/
+COPY --from=python38 /dbgpy/ python/
+COPY --from=python39 /dbgpy/ python/

--- a/test/structure-tests-python.yaml
+++ b/test/structure-tests-python.yaml
@@ -3,10 +3,20 @@ schemaVersion: 2.0.0
 fileExistenceTests:
   - name: 'ptvsd for python 2.7'
     path: '/duct-tape/python/lib/python2.7/site-packages/ptvsd/__init__.py'
+  - name: 'debugpy for python 2.7'
+    path: '/duct-tape/python/lib/python2.7/site-packages/debugpy/__init__.py'
   - name: 'ptvsd for python 3.7'
     path: '/duct-tape/python/lib/python3.7/site-packages/ptvsd/__init__.py'
+  - name: 'debugpy for python 3.7'
+    path: '/duct-tape/python/lib/python3.7/site-packages/debugpy/__init__.py'
   - name: 'ptvsd for python 3.8'
     path: '/duct-tape/python/lib/python3.8/site-packages/ptvsd/__init__.py'
+  - name: 'debugpy for python 3.8'
+    path: '/duct-tape/python/lib/python3.8/site-packages/debugpy/__init__.py'
+  - name: 'ptvsd for python 3.9'
+    path: '/duct-tape/python/lib/python3.9/site-packages/ptvsd/__init__.py'
+  - name: 'debugpy for python 3.9'
+    path: '/duct-tape/python/lib/python3.9/site-packages/debugpy/__init__.py'
 
 commandTests:
   - name: "run with no /dbg should fail"


### PR DESCRIPTION
Adds support for Python 3.9 (released Oct 5), and also installs `debugpy`.

Closes #42 
Closes #49 

