### PR TITLE
Update Go support to 1.15

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.6 as delve
+FROM golang:1.15 as delve
 
 ARG DELVE_VERSION=1.5.0
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -55,6 +55,14 @@ profiles:
       - op: add
         path: /build/artifacts/-
         value:
+          image: go115app
+          context: integration/goapp
+          docker:
+            buildArgs:
+              GOVERSION: 1.15
+      - op: add
+        path: /build/artifacts/-
+        value:
           image: nodejs12app
           context: integration/nodejsapp
           docker:


### PR DESCRIPTION
Removes the micro-version to pick up the latest (`golang:1.15` vs `golang:1.15.3`).