### PR TITLE
Publish images with more descriptive names

### DIFF
--- a/integration/k8s-test-go113.yaml
+++ b/integration/k8s-test-go113.yaml
@@ -28,7 +28,7 @@ spec:
     - mountPath: /dbg
       name: go-debugging-support
   initContainers:
-  - image: gcr.io/gcp-dev-tools/duct-tape/go
+  - image: skaffold-debug-go
     name: install-go-support
     resources: {}
     volumeMounts:
@@ -64,7 +64,7 @@ spec:
           name: kubectl
       containers:
       - name: dlv-to-go113
-        image: gcr.io/gcp-dev-tools/duct-tape/go
+        image: skaffold-debug-go
         command: [sh, -c, 'sleep 5;
           /kubectl/kubectl port-forward pod/go113pod 56286:56286 &
           sleep 2;

--- a/integration/k8s-test-go114.yaml
+++ b/integration/k8s-test-go114.yaml
@@ -28,7 +28,7 @@ spec:
     - mountPath: /dbg
       name: go-debugging-support
   initContainers:
-  - image: gcr.io/gcp-dev-tools/duct-tape/go
+  - image: skaffold-debug-go
     name: install-go-support
     resources: {}
     volumeMounts:
@@ -64,7 +64,7 @@ spec:
           name: kubectl
       containers:
       - name: dlv-to-go114
-        image: gcr.io/gcp-dev-tools/duct-tape/go
+        image: skaffold-debug-go
         command: [sh, -c, 'sleep 5;
           /kubectl/kubectl port-forward pod/go114pod 56286:56286 &
           sleep 2;

--- a/integration/k8s-test-go115.yaml
+++ b/integration/k8s-test-go115.yaml
@@ -28,7 +28,7 @@ spec:
     - mountPath: /dbg
       name: go-debugging-support
   initContainers:
-  - image: gcr.io/gcp-dev-tools/duct-tape/go
+  - image: skaffold-debug-go
     name: install-go-support
     resources: {}
     volumeMounts:
@@ -64,7 +64,7 @@ spec:
           name: kubectl
       containers:
       - name: dlv-to-go115
-        image: gcr.io/gcp-dev-tools/duct-tape/go
+        image: skaffold-debug-go
         command: [sh, -c, 'sleep 5;
           /kubectl/kubectl port-forward pod/go115pod 56286:56286 &
           sleep 2;

--- a/integration/k8s-test-nodejs12.yaml
+++ b/integration/k8s-test-nodejs12.yaml
@@ -23,7 +23,7 @@ spec:
     - mountPath: /dbg
       name: node-debugging-support
   initContainers:
-  - image: gcr.io/gcp-dev-tools/duct-tape/nodejs
+  - image: skaffold-debug-nodejs
     name: install-node-support
     resources: {}
     volumeMounts:

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
+set -eu
+
+# publish with longer image names
 skaffold build -p prod --default-repo gcr.io/k8s-skaffold/skaffold-debug-support
 skaffold build -p prod --default-repo gcr.io/gcp-dev-tools/duct-tape
+
+# the github project packages is a backup location; will need to
+# migrate to ghcr.io/googlecontainertools at some point
+skaffold build -p prod --default-repo docker.pkg.github.com/googlecontainertools/skaffold
+
+# publish with shorter (deprecated) image names
+skaffold build -p prod,deprecated-names --default-repo gcr.io/k8s-skaffold/skaffold-debug-support
+skaffold build -p prod,deprecated-names --default-repo gcr.io/gcp-dev-tools/duct-tape

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,25 +2,25 @@ apiVersion: skaffold/v1beta9
 kind: Config
 build:
   artifacts:
-  - image: go
+  - image: skaffold-debug-go
     context: go
-  - image: python
+  - image: skaffold-debug-python
     context: python
-  - image: netcore
+  - image: skaffold-debug-netcore
     context: netcore
-  - image: nodejs
+  - image: skaffold-debug-nodejs
     context: nodejs
   # ensure images are tagged with :latest
   tagPolicy:
     sha256: {}
 test:
-  - image: go
+  - image: skaffold-debug-go
     structureTests: [./test/structure-tests-go.yaml]
-  - image: python
+  - image: skaffold-debug-python
     structureTests: [./test/structure-tests-python.yaml]
-  - image: netcore
+  - image: skaffold-debug-netcore
     structureTests: [./test/structure-tests-netcore.yaml]
-  - image: nodejs
+  - image: skaffold-debug-nodejs
     structureTests: [./test/structure-tests-nodejs.yaml]
 deploy:
   kubectl:
@@ -78,3 +78,44 @@ profiles:
     build:
       local:
         push: true
+
+  # Use short (deprecated) image names: images were renamed so they were
+  # more easily distinguished from other images with similar names.
+  - name: deprecated-names
+    patches:
+      - op: replace
+        path: /build/artifacts/0/image
+        from: skaffold-debug-go
+        value: go
+      - op: replace
+        path: /test/0/image
+        from: skaffold-debug-go
+        value: go
+
+      - op: replace
+        path: /build/artifacts/1/image
+        from: skaffold-debug-python
+        value: python
+      - op: replace
+        path: /test/1/image
+        from: skaffold-debug-python
+        value: python
+
+      - op: replace
+        path: /build/artifacts/2/image
+        from: skaffold-debug-netcore
+        value: netcore
+      - op: replace
+        path: /test/2/image
+        from: skaffold-debug-netcore
+        value: netcore
+
+      - op: replace
+        path: /build/artifacts/3/image
+        from: skaffold-debug-nodejs
+        value: nodejs
+      - op: replace
+        path: /test/3/image
+        from: skaffold-debug-nodejs
+        value: nodejs
+


### PR DESCRIPTION
This PR renames the debug-support images to more descriptive forms of `skaffold-debug-xxx`.  It continues to publish the images to `gcr.io/k8s-skaffold/skaffold-debug-support` and `gcr.io/gcp-dev-tools/duct-tape` using the current short names

The motivation is that [Github's Packages for Docker Containers will be migrated to GHCR.io](https://docs.github.com/en/packages/guides/configuring-docker-for-use-with-github-packages#about-docker-and-github-packages).  Github Packages only offers a flat namespace within a project (e.g., `docker.pkg.github.com/googlecontainertools/skaffold/go`), and more important, GHCR.io only offers a flat namespace *within the organization* (e.g., `ghcr.io/googlecontainertools/go`), which risks terrible confusion.