### PR TITLE
Use dotnet/runtime:6.0 for linux/arm64 building

### DIFF
--- a/netcore/Dockerfile
+++ b/netcore/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 as netcore
+FROM mcr.microsoft.com/dotnet/runtime:6.0 as netcore
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
+    && apt-get install -y --no-install-recommends unzip curl \
     && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 
 # Now populate the duct-tape image with the language runtime debugging support files


### PR DESCRIPTION
Fixes #61 

This PR updates the `netcore` debug image to use the dotnet/runtime:6.0 image.  Although 6.0 is still under development, we only use it to grab VSDBG, and the same version of VSDBG is downloaded.