### PR TITLE
Warn when Python debugging library path is not found

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -7,7 +7,9 @@ PLATFORMS=linux/amd64,linux/arm64
 
 if ! docker buildx inspect skaffold-builder >/dev/null 2>&1; then
   echo ">> creating "docker buildx" builder 'skaffold-builder'"
-  docker buildx create --name skaffold-builder --platform $PLATFORMS
+  # Docker 3.3.0 require creating a builder within a context
+  docker context create skaffold
+  docker buildx create --name skaffold-builder --platform $PLATFORMS skaffold
 fi
 
 loadOrPush=$(if [ "$PUSH_IMAGE" = true ]; then echo --platform $PLATFORMS --push; else echo --load; fi)

--- a/python/helper-image/launcher/env.go
+++ b/python/helper-image/launcher/env.go
@@ -44,11 +44,11 @@ func (e env) AsPairs() []string {
 	return m
 }
 
-// PrependFilepath prepands a path to a environment variable.
-func (e env) PrependFilepath(key string, path string) {
+// AppendFilepath appands a path to a environment variable.
+func (e env) AppendFilepath(key string, path string) {
 	v := e[key]
 	if v != "" {
-		v = path + string(filepath.ListSeparator) + v
+		v = v + string(filepath.ListSeparator) + path
 	} else {
 		v = path
 	}

--- a/python/helper-image/launcher/env_test.go
+++ b/python/helper-image/launcher/env_test.go
@@ -80,7 +80,7 @@ func TestEnvFromPairs(t *testing.T) {
 	}
 }
 
-func TestEnvPrependFilepath(t *testing.T) {
+func TestEnvAppendFilepath(t *testing.T) {
 	tests := []struct {
 		description string
 		env         env
@@ -89,15 +89,15 @@ func TestEnvPrependFilepath(t *testing.T) {
 		expected    map[string]string
 	}{
 		{"empty", env{}, "PATH", "value", env{"PATH": "value"}},
-		{"existing value", env{"PATH": "other"}, "PATH", "value", env{"PATH": "value" + string(filepath.ListSeparator) + "other"}},
+		{"existing value", env{"PATH": "other"}, "PATH", "value", env{"PATH": "other" + string(filepath.ListSeparator) + "value"}},
 		{"other value unchanged", env{"PYTHONPATH": "other"}, "PATH", "value", env{"PATH": "value", "PYTHONPATH": "other"}},
-		{"existing value with other value unchanged", env{"PATH": "other", "PYTHONPATH": "other"}, "PATH", "value", env{"PATH": "value" + string(filepath.ListSeparator) + "other", "PYTHONPATH": "other"}},
+		{"existing value with other value unchanged", env{"PATH": "other", "PYTHONPATH": "other"}, "PATH", "value", env{"PATH": "other" + string(filepath.ListSeparator) + "value", "PYTHONPATH": "other"}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			result := test.env // not a copy but that's ok for this test
-			result.PrependFilepath(test.key, test.value)
+			result.AppendFilepath(test.key, test.value)
 			if len(result) != len(test.expected) {
 				t.Errorf("expected %v but got %v", test.expected, result)
 			} else {

--- a/python/helper-image/launcher/launcher_test.go
+++ b/python/helper-image/launcher/launcher_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -291,5 +292,14 @@ func TestLaunch(t *testing.T) {
 				_t.Errorf("%T differ (-got, +want): %s", pc, diff)
 			}
 		})
+	}
+}
+
+func TestPathExists(t *testing.T) {
+	if pathExists(filepath.Join("this", "should", "not", "exist")) {
+		t.Error("pathExists should have failed on non-existent path")
+	}
+	if !pathExists(t.TempDir()) {
+		t.Error("pathExists failed on real path")
 	}
 }


### PR DESCRIPTION
Fixes #68

Emits a warning if the calculated Python library location does not exist.  We don't error as the user may have explicitly installed the debug library themselves.
```
WARN[0000] Debugging support for Python 3.2 not found: may require manually installing "pydevd" 
```