### PR TITLE
Final debug helper images must be for target platform

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -23,7 +23,7 @@ RUN cd delve-source && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build 
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
-FROM --platform=$BUILDPLATFORM busybox
+FROM busybox
 # The install script copies all files in /duct-tape to /dbg
 COPY install.sh /
 CMD ["/bin/sh", "/install.sh"]

--- a/hack/enable-docker-buildkit.sh
+++ b/hack/enable-docker-buildkit.sh
@@ -6,11 +6,15 @@ if [ -f /etc/docker/daemon.json ]; then
     echo "/etc/docker/daemon.json was:"
     sed 's/^/> /' /etc/docker/daemon.json
     echo "/etc/docker/daemon.json now:"
-    jq '.+{"experimental":true}' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json
+    jq '.+{"experimental":true}' /etc/docker/daemon.json \
+    | jq '."registry-mirrors" += ["https://mirror.gcr.io"]' \
+    | sudo tee /etc/docker/daemon.json
 else
     sudo mkdir -vp /etc/docker
     echo "/etc/docker/daemon.json now:"
-    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+    echo '{"experimental":true}' \
+    | jq '."registry-mirrors" += ["https://mirror.gcr.io"]' \
+    | sudo tee /etc/docker/daemon.json
 fi
 
 if [ -f $HOME/.docker/config.json ]; then

--- a/netcore/helper-image/Dockerfile
+++ b/netcore/helper-image/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
-FROM --platform=$BUILDPLATFORM busybox
+FROM busybox
 ARG BUILDPLATFORM
 
 # The install script copies all files in /duct-tape to /dbg

--- a/nodejs/helper-image/Dockerfile
+++ b/nodejs/helper-image/Dockerfile
@@ -10,7 +10,7 @@ RUN GOPATH="" CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o node -
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
-FROM --platform=$BUILDPLATFORM busybox
+FROM busybox
 # The install script copies all files in /duct-tape to /dbg
 COPY install.sh /
 CMD ["/bin/sh", "/install.sh"]

--- a/python/helper-image/Dockerfile
+++ b/python/helper-image/Dockerfile
@@ -76,7 +76,7 @@ RUN GOPATH="" CGO_ENABLED=0 go build -o launcher -ldflags '-s -w -extldflags "-s
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
-FROM --platform=$BUILDPLATFORM busybox
+FROM busybox
 ARG BUILDPLATFORM
 
 # The install script copies all files in /duct-tape to /dbg


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/cloud-code-samples/issues/721

The debug support images are `busybox` images is essentially a little script that copies set of files required for a particular language runtime to a specific directory.  This script is a Bourne shell script.

Due to an error in the Dockerfiles, these debug support images were being created using the build-platform's os/arch.  As the images are built from a linux/amd64, the linux/arm64 debug support image had a linux/amd64 `/bin/sh` and so failed on a linux/arm64.  My testing is on an Apple M1 with Docker Desktop, which includes qemu-based binfmt_misc binaries and so silently executes linux/amd64 binaries.