### PR TITLE
go: upgrade delve to 1.7.2

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.6.0
+ARG DELVE_VERSION=1.7.2
 
 RUN curl --location --output delve-$DELVE_VERSION.tar.gz https://github.com/go-delve/delve/archive/v$DELVE_VERSION.tar.gz \
   && tar xzf delve-$DELVE_VERSION.tar.gz \


### PR DESCRIPTION
Upgrade delve to 1.7.2.

Ref: https://github.com/go-delve/delve/releases/tag/v1.7.2