### PR TITLE
ci: update rbac.authorization.k8s.io/ClusterRoleBinding to v1

### DIFF
--- a/integration/k8s-rbac.yaml
+++ b/integration/k8s-rbac.yaml
@@ -1,6 +1,6 @@
 # Simple RBAC required to enable use of `kubectl port-forward`
 # from within a container.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: default-rbac


### PR DESCRIPTION
`rbac.authorization.k8s.io graduated` to `v1` in Kubernetes 1.17 and [`v1beta1` was removed in Kubernetes 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122).