### PR TITLE
chore: use curl image for netcore for faster build

### DIFF
--- a/netcore/helper-image/Dockerfile
+++ b/netcore/helper-image/Dockerfile
@@ -1,15 +1,17 @@
-FROM mcr.microsoft.com/dotnet/runtime:6.0 as netcore
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip curl \
-    && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
+FROM --platform=$BUILDPLATFORM curlimages/curl as netcore
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+# assume glibc; RuntimeIDs gleaned from the getvsdbgsh script
+RUN RuntimeID=$(case "$TARGETPLATFORM" in linux/amd64) echo linux-x64;; linux/arm64) echo linux-arm64;; *) exit 1;; esac); \
+ mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgsh | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger
-FROM busybox
-ARG BUILDPLATFORM
+FROM --platform=$TARGETPLATFORM busybox
+ARG TARGETPLATFORM
 
 # The install script copies all files in /duct-tape to /dbg
 COPY install.sh /
 CMD ["/bin/sh", "/install.sh"]
 WORKDIR /duct-tape
-COPY --from=netcore /vsdbg/ netcore/
+COPY --from=netcore /home/curl_user/vsdbg/ netcore/


### PR DESCRIPTION
The .NET Core helper image build simply downloads and extracts `vsdbg` using a Microsoft-provided script.  The script doesn't actually need a .NET Core installation to run.  So speed up the netcore image build by using the much smaller curl base image and use BuildKit-style multiplatform build to avoid having to run under emulation.