### PR TITLE
ci: add gcb script to promote images on GitHub release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,71 @@ again.
 2. Fork the repository into your own Github account.
 3. Please include unit tests (and integration tests if applicable) for all new code.
 4. Make sure all existing tests pass.
-   * TBD
 5. Associate the change with an existing issue or file a [new issue](../../issues).
 6. Create a pull request!
+
+
+# Development
+
+This project uses Skaffold's multiple config support to allow
+developing for each language runtime separately.
+
+Each language runtime is broken out to a separate directory
+with a `skaffold.yaml` for development of the `duct-tape` initContainer
+image.  Each image is expected to be standalone and should not require
+downloading additional content across the network.  To add support for a new
+language runtime, an image definition should download the necessary
+files into the container image.  The image's entrypoint should then
+copy those files into place at `/dbg/<runtime>`.  The image should
+be added to the respective `skaffold.yaml` and referenced within
+`test/k8s-*-installation.yaml`.
+
+We currently build language support images for both `linux/amd64` and
+`linux/arm64`.
+
+Images are currently published with two names: the short-form (like
+`go`) and a longer-form (`skaffold-debug-go`).  The short-forms are
+marked as deprecated as we intend to move away from, but they are
+still used by Skaffold.
+
+## Testing
+
+Integration tests are found under each language runtime directory in
+`test/`.  These tests build and launch applications as pods that
+are similar to the transformed form produced by `skaffold debug`.
+To run:
+
+```sh
+sh run-its.sh
+```
+
+You can run this script from a language-runtime location too to
+test only that runtime's support:
+
+```sh
+cd nodejs
+sh ../run-its.sh
+```
+
+# Staging and Deploying
+
+To stage a set of images for testing use the following command,
+where `$REPO` is the image repository where you plan to host the
+images.
+```sh
+skaffold build -p release,deprecated-names --default-repo $REPO
+```
+
+The `release` profile causes the images to be pushed to the specified
+repository and also enables multi-arch builds using buildx (default
+`linux/amd64` and `linux/arm64`).  The `deprecated-names` profile enables
+using the short-form image names (`go`, `netcore`, `nodejs`, `python`)
+that are currently used by `skaffold debug`.
+
+Then configure Skaffold to point to that location:
+```sh
+skaffold config set --global debug-helpers-registry $REPO
+```
+
+You should then be able to use `skaffold debug` with the
+staged images.

--- a/hack/cloudbuild-promote.yaml
+++ b/hack/cloudbuild-promote.yaml
@@ -1,0 +1,152 @@
+#
+# Use GitHub releases to promote container-debug-support images
+
+# We use GitHub release triggers to promote the images corresponding to
+# the release commit from staging ($_STAGING) to the production location ($_PROD).
+# Images are tagged with the $SHORT_SHA and $TAG_NAME where appropriate.
+#
+# Release tags ($TAG_NAME) are expected to follow a `vN.N` pattern and are
+# expected to be distinct.  The `vN` indicates a major version (e.g., v1.35 -> v1).
+# These release tags are generally expected to be distinct, such that they
+# shouldn't be overwritten by accident.
+# 
+# This promotion script copies the long- and short-form images to:
+#
+#   1. $_PROD/$TAG_NAME tagged with `latest` and `$SHORT_SHA`
+#      Users can then use a specific release with:
+#      ```
+#        skaffold config set --global debug-helpers-registry $_PROD/$TAG_NAME
+#      ```
+#   2. $_PROD/$MAJORVER tagged with `latest`, `$TAG_NAME`, and `$SHORT_SHA`,
+#      when $_IS_LATEST is true and $TAG_NAME has a valid major version
+#   3. $_PROD for backward compatibility, tagged with `latest`, `$TAG_NAME`, and `$SHORT_NAME`,
+#      when $_IS_LATEST is true and the major version is `v1`.
+#
+# For example, tagging commit 70f0f74 as v1.1 should result in the images being
+# copied over as:
+#
+#   1. gcr.io/k8s-skaffold/skaffold-debug-support/v1.1/<image>:{latest,70f0f74}
+#   2. gcr.io/k8s-skaffold/skaffold-debug-support/v1/<image>:{latest,v1.1,70f0f74}
+#   3. gcr.io/k8s-skaffold/skaffold-debug-support/<image>:{latest,v1.1,70f0f74}
+#
+# The last location (3) occurs because the major version is v1. This copy is to maintain
+# backwards compatibility with the existing versions of Skaffold.  When we bump the
+# major version to v2, we will no longer copy images into (3).
+#
+# To test:
+# $ export CLOUDSDK_CORE_PROJECT=bdealwis-playground
+# $ gcloud builds submit --config=hack/cloudbuild-promote.yaml \
+#    --substitutions=SHORT_SHA=999999,TAG_NAME=v1.23,_STAGING=us-central1-docker.pkg.dev/$CLOUDSDK_CORE_PROJECT/junk/skaffold-debug-support,_PROD=gcr.io/$CLOUDSDK_CORE_PROJECT/skaffold-debug-support
+#
+# To replace a previous release with rebuilt images:
+# $ gcloud builds submit --config=hack/cloudbuild-promote.yaml \
+#    --substitutions=SHORT_SHA=xxxx,TAG_NAME=v1.23,_STAGING=us-central1-docker.pkg.dev/$CLOUDSDK_CORE_PROJECT/junk/skaffold-debug-support,_PROD=gcr.io/$CLOUDSDK_CORE_PROJECT/skaffold-debug-support,_IS_LATEST=0
+#
+options:
+  #machineType: 'E2_HIGHCPU_8'
+
+substitutions:
+  _STAGING: us-central1-docker.pkg.dev/$PROJECT_ID/skaffold-staging/skaffold-debug-support
+  _PROD: gcr.io/$PROJECT_ID/skaffold-debug-support
+  _RUNTIMES: go netcore nodejs python
+  _IS_LATEST: "1"
+
+steps:
+  ###################################################################
+  # Validate that $TAG_NAME is an acceptable image component name and tag
+  # Regexs from https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+  - id: validate-tag
+    name: bash
+    entrypoint: 'bash'
+    args:
+      - '-eEuo'
+      - 'pipefail'
+      - '-c'
+      - |-
+        if [[ "$TAG_NAME" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]] \
+            && [[ "$TAG_NAME" =~ ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$ ]]; then
+          echo "Accepted tag"
+        else
+          echo "Release tag [$TAG_NAME] is not a valid image name component or image tag"
+          exit 1
+        fi
+  
+  ###################################################################
+  # Copy the staged images to release loction in $_PROD/$TAG_NAME.
+  # This allows users to use a specific release with:
+  #   skaffold config set --global debug-helpers-registry $_PROD/$TAG_NAME
+  #
+  # First copy staged images into $_PROD/$TAG_NAME tagged with $SHORT_SHA.  
+  # If this step fails, then nothing irrevocable has occurred.
+  - id: install-release-images
+    name: gcr.io/go-containerregistry/gcrane:debug
+    entrypoint: /busybox/sh
+    args:
+    - "-euc"
+    - |-
+      for runtime in $_RUNTIMES; do
+        gcrane copy $_STAGING/$SHORT_SHA/skaffold-debug-$$runtime:latest $_PROD/$TAG_NAME/skaffold-debug-$$runtime:$SHORT_SHA
+        gcrane copy $_STAGING/$SHORT_SHA/$$runtime:latest $_PROD/$TAG_NAME/$$runtime:$SHORT_SHA
+      done
+  # Then install these images by tagging them with `latest`.
+  - id: promote-release-images
+    name: gcr.io/go-containerregistry/gcrane:debug
+    entrypoint: /busybox/sh
+    args:
+    - "-euc"
+    - |-
+      for runtime in $_RUNTIMES; do
+        gcrane tag $_PROD/$TAG_NAME/skaffold-debug-$$runtime:$SHORT_SHA latest
+        gcrane tag $_PROD/$TAG_NAME/$$runtime:$SHORT_SHA latest
+      done
+      echo "Images promoted to $_PROD/$TAG_NAME"
+  
+  # Promote to major version (e.g., v1.35 -> v1).
+  # If IS_LATEST=1 copy these tagged images into latest.
+  - id: promote-to-major-version
+    name: gcr.io/go-containerregistry/gcrane:debug
+    entrypoint: /busybox/sh
+    args:
+    - "-euc"
+    - |-
+      MAJORVER=$$(echo $TAG_NAME | sed -n 's/\(v[0-9][0-9]\)*\.[0-9.]*/\1/p')
+      if [ -z "$$MAJORVER" ]; then
+      	echo "Skipping rest of promotion: Release tag [${TAG_NAME}] does not have [vN.*] major version"
+      	exit 0
+      fi
+
+      for runtime in $_RUNTIMES; do
+        gcrane copy $_STAGING/$SHORT_SHA/skaffold-debug-$$runtime:latest $_PROD/$$MAJORVER/skaffold-debug-$$runtime:$SHORT_SHA
+        gcrane copy $_STAGING/$SHORT_SHA/$$runtime:latest $_PROD/$$MAJORVER/$$runtime:$SHORT_SHA
+        if [ "$$MAJORVER" = v1 ]; then
+          gcrane copy $_STAGING/$SHORT_SHA/skaffold-debug-$$runtime:latest $_PROD/skaffold-debug-$$runtime:$SHORT_SHA
+          gcrane copy $_STAGING/$SHORT_SHA/$$runtime:latest $_PROD/$$runtime:$SHORT_SHA
+        fi
+      done
+      for runtime in $_RUNTIMES; do
+        gcrane tag $_PROD/$$MAJORVER/skaffold-debug-$$runtime:$SHORT_SHA $TAG_NAME
+        gcrane tag $_PROD/$$MAJORVER/$$runtime:$SHORT_SHA $TAG_NAME
+        if [ "$$MAJORVER" = v1 ]; then
+          gcrane tag $_PROD/skaffold-debug-$$runtime:$SHORT_SHA $TAG_NAME
+          gcrane tag $_PROD/$$runtime:$SHORT_SHA $TAG_NAME
+        fi
+      done
+      case "$_IS_LATEST" in
+      0|no|NO|false|FALSE) echo "skipping promotion to latest as _IS_LATEST=${_IS_LATEST}"; exit 0;;
+      esac
+      
+      for runtime in $_RUNTIMES; do
+        gcrane tag $_PROD/$$MAJORVER/skaffold-debug-$$runtime:$SHORT_SHA latest
+        gcrane tag $_PROD/$$MAJORVER/$$runtime:$SHORT_SHA latest
+      done
+      echo "Images promoted to $_PROD/$$MAJORVER as latest"
+
+      if [ "$$MAJORVER" = v1 ]; then
+        for runtime in $_RUNTIMES; do
+          gcrane tag $_PROD/skaffold-debug-$$runtime:$SHORT_SHA latest
+          gcrane tag $_PROD/$$runtime:$SHORT_SHA latest
+        done
+        echo "Images promoted to $_PROD as latest"
+      fi
+
+timeout: 200s


### PR DESCRIPTION
This PR adds a GCB script to handle promoting images to `gcr.io/k8s-skaffold/skaffold-debug-support` as triggered by a GitHub release tagging event.  Currently the images are promoted by hand, and there is no easy way for users to rollback to an earlier set of images.  It is also difficult to trace back an image to the corresponding commit.

## Approach

With the approach encoded in this promotion script, images are copied into `gcr.io/k8s-skaffold/skaffold-debug-support` and be promoted to `latest`.  The images are copied in using a naming scheme that allows users to easily use images from a specific release.  Images are also tagged with the SHORT-SHA of the commit; this is admittedly imperfect and #110 tracks embedding this information as image annotations.

Release tags are generally expected (though not required) to follow a tagging format like `v1.0`, with a major and minor version.  On a release, this script will place the resulting images in

    gcr.io/k8s-skaffold/skaffold-debug-support/<release>

The images in this location will be tagged as both `latest` and with the commit's `<SHORT-SHA>`.  This allows users to use these images by setting the Skaffold global config property `debug-helpers-registry`.

If the `<release>` has a major version (e.g., `v1.1` has major version `v1`), then the images will furthermore be placed in

    gcr.io/k8s-skaffold/skaffold-debug-support/<major-version>

tagged with `<release>` and `<SHORT-SHA>`.  When `_IS_LATEST=1` (the default), then the images will also be tagged with `latest`.  So users can use the latest version within a major-release without having to track the specific release.

There is an additional special case: if the major version is `v1` and `_IS_LATEST=1` (the default), then the images will also be copied to 

    gcr.io/k8s-skaffold/skaffold-debug-support/

and tagged with `latest`, `<major-version>`, and `<SHORT-SHA>`.  This maintains backwards compatibility with the deployed Skaffold installations.  The intention is that the current images will be released as `v1.0`.

## How it works

Currently this project has a [GCB script](https://github.com/GoogleContainerTools/container-debug-support/blob/duct-tape/hack/cloudbuild-staging.yaml) that builds images on each commit to HEAD and stores the results under

    us-central1-docker.pkg.dev/k8s-skaffold/skaffold-staging/skaffold-debug-support/<SHORT-SHA>

On a release tag, this new `cloudbuild-promote.yaml` script copies out the staged images for the corresponding commit SHA1 and places them into `gcr.io/k8s-skaffold/skaffold-debug-support/` using the rules described above.

## Further work

- #110 
- publish images to github packages: https://github.com/GoogleContainerTools/skaffold/issues/4521