### PR TITLE
ci: fix GCB substitutions for promotion script

### DIFF
--- a/hack/cloudbuild-promote.yaml
+++ b/hack/cloudbuild-promote.yaml
@@ -46,10 +46,12 @@ options:
   #machineType: 'E2_HIGHCPU_8'
 
 substitutions:
-  _STAGING: us-central1-docker.pkg.dev/$PROJECT_ID/skaffold-staging/skaffold-debug-support
-  _PROD: gcr.io/$PROJECT_ID/skaffold-debug-support
+  _STAGING: us-central1-docker.pkg.dev/${PROJECT_ID}/skaffold-staging/skaffold-debug-support
+  _PROD: gcr.io/${PROJECT_ID}/skaffold-debug-support
   _RUNTIMES: go netcore nodejs python
   _IS_LATEST: "1"
+options:
+  dynamic_substitutions: true
 
 steps:
   ###################################################################


### PR DESCRIPTION
[Promotion for v1.1.0](https://console.cloud.google.com/cloud-build/builds;region=global/38aff40b-6768-4f6a-b382-930e847296c3?project=k8s-skaffold) is failing in step `install-release-images`:
```
...
Digest: sha256:6b364e17fb9a564daaa829d89219195a21fd63bfa56ddcd66b54be0dab87cdce
Status: Downloaded newer image for gcr.io/go-containerregistry/gcrane:debug
gcr.io/go-containerregistry/gcrane:debug
/busybox/sh: PROJECT_ID: parameter not set
```