### PR TITLE
fix(python): debugpy requires `-m module`

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install required tools
       run: |
-        set -e
+        set -ex
         mkdir -p $HOME/bin
         curl -Lo $HOME/bin/skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
         curl -Lo $HOME/bin/container-structure-test https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
@@ -46,17 +46,17 @@ jobs:
 
     - name: Run nodejs helper tests
       run: |
-        set -e
+        set -ex
         (cd nodejs/helper-image; go test .)
 
     - name: Run python helper tests
       run: |
-        set -e
+        set -ex
         (cd python/helper-image/launcher; go test .)
 
     - name: Run image build
       run: |
-        set -e
+        set -ex
         # Create a kind configuration to use the docker daemon's configured registry-mirrors.
         docker system info --format '{{printf "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\ncontainerdConfigPatches:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = %q\n" $reg $config.Mirrors}}{{end}}{{end}}' > /tmp/kind.config
 

--- a/python/helper-image/launcher/launcher.go
+++ b/python/helper-image/launcher/launcher.go
@@ -350,6 +350,7 @@ func (pc *pythonContext) updateEnv(ctx context.Context) error {
 }
 
 func (pc *pythonContext) updateCommandLine(ctx context.Context) error {
+	// TODO(#76): we're assuming the `-m module` argument comes first
 	var cmdline []string
 	switch pc.debugMode {
 	case ModePtvsd:

--- a/python/helper-image/launcher/launcher.go
+++ b/python/helper-image/launcher/launcher.go
@@ -367,7 +367,14 @@ func (pc *pythonContext) updateCommandLine(ctx context.Context) error {
 		if pc.wait {
 			cmdline = append(cmdline, "--wait-for-client")
 		}
-		cmdline = append(cmdline, pc.args[1:]...)
+		// debugpy expects the `-m` module argument to be separate
+		for i, arg := range pc.args[1:] {
+			if i == 0 && arg != "-m" && strings.HasPrefix(arg, "-m") {
+				cmdline = append(cmdline, "-m", strings.TrimPrefix(arg, "-m"))			
+			} else {				
+				cmdline = append(cmdline, arg)
+			}
+		}
 		pc.args = cmdline
 
 	case ModePydevd, ModePydevdPycharm:

--- a/python/helper-image/launcher/launcher_test.go
+++ b/python/helper-image/launcher/launcher_test.go
@@ -253,6 +253,20 @@ func TestPrepare(t *testing.T) {
 			expected: pythonContext{debugMode: "debugpy", port: 2345, wait: false, major: 3, minor: 7, args: []string{"python", "-m", "debugpy", "--listen", "2345", "app.py"}, env: env{"PYTHONPATH": dbgRoot + "/python/lib/python3.7/site-packages"}},
 		},
 		{
+			description: "debugpy with module",
+			pc:          pythonContext{debugMode: "debugpy", port: 2345, wait: false, args: []string{"python", "-m", "gunicorn", "app:app"}, env: nil},
+			commands: RunCmdOut([]string{"python", "-V"}, "Python 3.7.4\n").
+				AndRunCmd([]string{"python", "-m", "debugpy", "--listen", "2345", "app.py"}),
+			expected: pythonContext{debugMode: "debugpy", port: 2345, wait: false, major: 3, minor: 7, args: []string{"python", "-m", "debugpy", "--listen", "2345", "-m", "gunicorn", "app:app"}, env: env{"PYTHONPATH": dbgRoot + "/python/lib/python3.7/site-packages"}},
+		},
+		{
+			description: "debugpy with module (no space)",
+			pc:          pythonContext{debugMode: "debugpy", port: 2345, wait: false, args: []string{"python", "-mgunicorn", "app:app"}, env: nil},
+			commands: RunCmdOut([]string{"python", "-V"}, "Python 3.7.4\n").
+				AndRunCmd([]string{"python", "-m", "debugpy", "--listen", "2345", "app.py"}),
+			expected: pythonContext{debugMode: "debugpy", port: 2345, wait: false, major: 3, minor: 7, args: []string{"python", "-m", "debugpy", "--listen", "2345", "-m", "gunicorn", "app:app"}, env: env{"PYTHONPATH": dbgRoot + "/python/lib/python3.7/site-packages"}},
+		},
+		{
 			description: "debugpy with wait",
 			pc:          pythonContext{debugMode: "debugpy", port: 2345, wait: true, args: []string{"python", "app.py"}, env: nil},
 			commands: RunCmdOut([]string{"python", "-V"}, "Python 3.7.4\n").


### PR DESCRIPTION
Fixes #114

Ensure `-mmodule` arguments are transformed to `-m module` arguments for debugpy.