### PR TITLE
feat(go): support Go 1.19 and Delve 1.9.1

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -1,10 +1,10 @@
-ARG GOVERSION=1.17
+ARG GOVERSION=1.19
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION} as delve
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.8.1
+ARG DELVE_VERSION=1.9.1
 
 # Patch delve to make defaults for --check-go-version and --only-same-user
 # to be set at build time.  We must install patch(1) to apply the patch.

--- a/go/skaffold.yaml
+++ b/go/skaffold.yaml
@@ -78,6 +78,22 @@ profiles:
           docker:
             buildArgs:
               GOVERSION: 1.17
+      - op: add
+        path: /build/artifacts/-
+        value:
+          image: go118app
+          context: test/goapp
+          docker:
+            buildArgs:
+              GOVERSION: 1.18
+      - op: add
+        path: /build/artifacts/-
+        value:
+          image: go119app
+          context: test/goapp
+          docker:
+            buildArgs:
+              GOVERSION: 1.19
     deploy:
       kubectl:
         manifests:
@@ -86,6 +102,8 @@ profiles:
           - test/k8s-test-go115.yaml
           - test/k8s-test-go116.yaml
           - test/k8s-test-go117.yaml
+          - test/k8s-test-go118.yaml
+          - test/k8s-test-go119.yaml
 
   # release: pushes images to production with :latest
   - name: release

--- a/go/test/k8s-test-go118.yaml
+++ b/go/test/k8s-test-go118.yaml
@@ -1,0 +1,91 @@
+# This test approximates `skaffold debug` for a go app.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go118pod
+  labels:
+    app: hello
+    protocol: dlv
+    runtime: go118
+spec:
+  containers:
+  - name: go118app
+    image: go118app
+    args:
+    - /dbg/go/bin/dlv
+    - exec
+    - --log
+    - --headless
+    - --continue
+    - --accept-multiclient
+    # listen on 0.0.0.0 as it is exposed as a service
+    - --listen=0.0.0.0:56286
+    - --api-version=2
+    - ./app
+    ports:
+    - containerPort: 8080
+    - containerPort: 56286
+      name: dlv
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  initContainers:
+  - image: skaffold-debug-go
+    name: install-go-support
+    resources: {}
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  volumes:
+  - emptyDir: {}
+    name: go-debugging-support
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-dlv-go118
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  - name: dlv
+    port: 56286
+    protocol: TCP
+  selector:
+    app: hello
+    protocol: dlv
+    runtime: go118
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connect-to-go118
+  labels:
+    project: container-debug-support
+    type: integration-test
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-go118pod
+        image: kubectl
+        command: [sh, -c, "while ! curl -s hello-dlv-go118:8080 2>/dev/null; do echo waiting for app; sleep 1; done"]
+      containers:
+      - name: dlv-to-go118
+        image: skaffold-debug-go
+        command: [sh, -c, '
+          (echo bt; echo exit -c) > init.txt;
+          set -x;
+          /duct-tape/go/bin/dlv connect --init init.txt hello-dlv-go118:56286']
+
+

--- a/go/test/k8s-test-go119.yaml
+++ b/go/test/k8s-test-go119.yaml
@@ -1,0 +1,91 @@
+# This test approximates `skaffold debug` for a go app.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go119pod
+  labels:
+    app: hello
+    protocol: dlv
+    runtime: go119
+spec:
+  containers:
+  - name: go119app
+    image: go119app
+    args:
+    - /dbg/go/bin/dlv
+    - exec
+    - --log
+    - --headless
+    - --continue
+    - --accept-multiclient
+    # listen on 0.0.0.0 as it is exposed as a service
+    - --listen=0.0.0.0:56286
+    - --api-version=2
+    - ./app
+    ports:
+    - containerPort: 8080
+    - containerPort: 56286
+      name: dlv
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  initContainers:
+  - image: skaffold-debug-go
+    name: install-go-support
+    resources: {}
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  volumes:
+  - emptyDir: {}
+    name: go-debugging-support
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-dlv-go119
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  - name: dlv
+    port: 56286
+    protocol: TCP
+  selector:
+    app: hello
+    protocol: dlv
+    runtime: go119
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connect-to-go119
+  labels:
+    project: container-debug-support
+    type: integration-test
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-go119pod
+        image: kubectl
+        command: [sh, -c, "while ! curl -s hello-dlv-go119:8080 2>/dev/null; do echo waiting for app; sleep 1; done"]
+      containers:
+      - name: dlv-to-go119
+        image: skaffold-debug-go
+        command: [sh, -c, '
+          (echo bt; echo exit -c) > init.txt;
+          set -x;
+          /duct-tape/go/bin/dlv connect --init init.txt hello-dlv-go119:56286']
+
+


### PR DESCRIPTION
Add support for Go 1.19 by updating to Delve 1.9.1.  Although Delve 1.9.1 drops support for older versions of Go, our tests show that it does still work.

Fixes #118