### PR TITLE
feat(go): support Go 1.20 and Delve 1.20.1

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -1,10 +1,10 @@
-ARG GOVERSION=1.19
+ARG GOVERSION=1.20
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION} as delve
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.9.1
+ARG DELVE_VERSION=1.20.1
 
 # Patch delve to make defaults for --check-go-version and --only-same-user
 # to be set at build time.  We must install patch(1) to apply the patch.

--- a/go/skaffold.yaml
+++ b/go/skaffold.yaml
@@ -94,6 +94,14 @@ profiles:
           docker:
             buildArgs:
               GOVERSION: 1.19
+      - op: add
+        path: /build/artifacts/-
+        value:
+          image: go120app
+          context: test/goapp
+          docker:
+            buildArgs:
+              GOVERSION: 1.20
     deploy:
       kubectl:
         manifests:

--- a/go/test/k8s-test-go120.yaml
+++ b/go/test/k8s-test-go120.yaml
@@ -1,0 +1,91 @@
+# This test approximates `skaffold debug` for a go app.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go120pod
+  labels:
+    app: hello
+    protocol: dlv
+    runtime: go120
+spec:
+  containers:
+  - name: go120app
+    image: go120app
+    args:
+    - /dbg/go/bin/dlv
+    - exec
+    - --log
+    - --headless
+    - --continue
+    - --accept-multiclient
+    # listen on 0.0.0.0 as it is exposed as a service
+    - --listen=0.0.0.0:56286
+    - --api-version=2
+    - ./app
+    ports:
+    - containerPort: 8080
+    - containerPort: 56286
+      name: dlv
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  initContainers:
+  - image: skaffold-debug-go
+    name: install-go-support
+    resources: {}
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  volumes:
+  - emptyDir: {}
+    name: go-debugging-support
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-dlv-go120
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  - name: dlv
+    port: 56286
+    protocol: TCP
+  selector:
+    app: hello
+    protocol: dlv
+    runtime: go120
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connect-to-go120
+  labels:
+    project: container-debug-support
+    type: integration-test
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-go120pod
+        image: kubectl
+        command: [sh, -c, "while ! curl -s hello-dlv-go120:8080 2>/dev/null; do echo waiting for app; sleep 1; done"]
+      containers:
+      - name: dlv-to-go120
+        image: skaffold-debug-go
+        command: [sh, -c, '
+          (echo bt; echo exit -c) > init.txt;
+          set -x;
+          /duct-tape/go/bin/dlv connect --init init.txt hello-dlv-go120:56286']
+
+


### PR DESCRIPTION
Debugging containers built with go1.20 does not work with the latest release since delve is not up to date (see https://github.com/go-delve/delve/blob/master/CHANGELOG.md#1201-2022-12-12, support for go1.20 was added in delve 1.20).

This PR basically mirrors the structure defined in https://github.com/GoogleContainerTools/container-debug-support/commit/a8b41f5c21645275e6885dbefe82924b97a56e1b, hope that works.