### PR TITLE
fix: disable CGO on Go test app, remove deprecated `--DEBUG` flag in pydevd, and remove tests for unsupported Go versions

### DIFF
--- a/go/skaffold.yaml
+++ b/go/skaffold.yaml
@@ -41,46 +41,6 @@ profiles:
       - op: add
         path: /build/artifacts/-
         value:
-          image: go113app
-          context: test/goapp
-          docker:
-            buildArgs:
-              GOVERSION: 1.13
-      - op: add
-        path: /build/artifacts/-
-        value:
-          image: go114app
-          context: test/goapp
-          docker:
-            buildArgs:
-              GOVERSION: 1.14
-      - op: add
-        path: /build/artifacts/-
-        value:
-          image: go115app
-          context: test/goapp
-          docker:
-            buildArgs:
-              GOVERSION: 1.15
-      - op: add
-        path: /build/artifacts/-
-        value:
-          image: go116app
-          context: test/goapp
-          docker:
-            buildArgs:
-              GOVERSION: 1.16
-      - op: add
-        path: /build/artifacts/-
-        value:
-          image: go117app
-          context: test/goapp
-          docker:
-            buildArgs:
-              GOVERSION: 1.17
-      - op: add
-        path: /build/artifacts/-
-        value:
           image: go118app
           context: test/goapp
           docker:
@@ -105,11 +65,6 @@ profiles:
     deploy:
       kubectl:
         manifests:
-          - test/k8s-test-go113.yaml
-          - test/k8s-test-go114.yaml
-          - test/k8s-test-go115.yaml
-          - test/k8s-test-go116.yaml
-          - test/k8s-test-go117.yaml
           - test/k8s-test-go118.yaml
           - test/k8s-test-go119.yaml
           - test/k8s-test-go120.yaml

--- a/go/test/goapp/Dockerfile
+++ b/go/test/goapp/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 COPY main.go .
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="all=-N -l" -o /app main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="all=-N -l" -o /app main.go
 
 FROM --platform=$BUILDPLATFORM gcr.io/distroless/base
 CMD ["./app"]

--- a/python/helper-image/launcher/launcher.go
+++ b/python/helper-image/launcher/launcher.go
@@ -41,8 +41,8 @@ limitations under the License.
 //
 // This launcher is expected to be invoked as follows:
 //
-//    launcher --mode <pydevd|pydevd-pycharm|debugpy|ptvsd> \
-//        --port p [--wait] -- original-command-line ...
+//	launcher --mode <pydevd|pydevd-pycharm|debugpy|ptvsd> \
+//	    --port p [--wait] -- original-command-line ...
 //
 // This launcher determines the python executable based on
 // `original-command-line`, unwrapping any python scripts, and
@@ -65,22 +65,24 @@ limitations under the License.
 // ```
 // and will then invoke:
 // ```
-// python -m pydevd --server --port 5678 --DEBUG --continue \
-//   --file /tmp/pydevd716531212/skaffold_pydevd_launch.py
+//
+//	python -m pydevd --server --port 5678 --continue \
+//	  --file /tmp/pydevd716531212/skaffold_pydevd_launch.py
+//
 // ```
 //
 // The launcher can be configured through several environment
 // variables:
 //
-// - Set `WRAPPER_ENABLED=false` to disable the launcher: the
-//   launcher will execute the original-command-line as-is.
-// - Set `WRAPPER_SKIP_ENV=true` to avoid setting PYTHONPATH
-//   to point to bundled debugging backends: this is useful if
-//   your app already includes `debugpy`.
-// - Set `WRAPPER_PYTHON_VERSION=3.9` to avoid trying to determine
-//   the python version by executing `python -V`
-// - Set `WRAPPER_VERBOSE` to one of `error`, `warn`, `info`, `debug`,
-//   or `trace` to reduce or increase the verbosity
+//   - Set `WRAPPER_ENABLED=false` to disable the launcher: the
+//     launcher will execute the original-command-line as-is.
+//   - Set `WRAPPER_SKIP_ENV=true` to avoid setting PYTHONPATH
+//     to point to bundled debugging backends: this is useful if
+//     your app already includes `debugpy`.
+//   - Set `WRAPPER_PYTHON_VERSION=3.9` to avoid trying to determine
+//     the python version by executing `python -V`
+//   - Set `WRAPPER_VERBOSE` to one of `error`, `warn`, `info`, `debug`,
+//     or `trace` to reduce or increase the verbosity
 package main
 
 import (
@@ -371,8 +373,8 @@ func (pc *pythonContext) updateCommandLine(ctx context.Context) error {
 		// debugpy expects the `-m` module argument to be separate
 		for i, arg := range pc.args[1:] {
 			if i == 0 && arg != "-m" && strings.HasPrefix(arg, "-m") {
-				cmdline = append(cmdline, "-m", strings.TrimPrefix(arg, "-m"))			
-			} else {				
+				cmdline = append(cmdline, "-m", strings.TrimPrefix(arg, "-m"))
+			} else {
 				cmdline = append(cmdline, arg)
 			}
 		}
@@ -382,9 +384,6 @@ func (pc *pythonContext) updateCommandLine(ctx context.Context) error {
 		// Appropriate location to resolve pydevd is set in updateEnv
 		cmdline = append(cmdline, pc.args[0])
 		cmdline = append(cmdline, "-m", "pydevd", "--server", "--port", strconv.Itoa(int(pc.port)))
-		if pc.env["WRAPPER_VERBOSE"] != "" {
-			cmdline = append(cmdline, "--DEBUG")
-		}
 		if !pc.wait {
 			cmdline = append(cmdline, "--continue")
 		}


### PR DESCRIPTION
This PR includes the following changes:
- Set `CGO_ENABLE=0` when building the Go test app: for Go 1.19 and 1.20 we were getting an error due the missing dependency, making the tests to fail during Skaffold's "deployment status check" phase
- Remove the `--DEBUG` flag in the python helper image launcher when using pydevd: the flag was deprecated
- Remove tests for unsupported Go versions (https://go.dev/doc/devel/release#policy): we'll stop running the test for the following Go versions: 1.13, 1.14, 1.15, 1.16, 1.17; this doesn't mean that those versions will not be supported by `skaffold debug`, we'll just stop running tests against them. This also will help us with some disk usage error we are getting during the tests 
