### PR TITLE
feat(go): support Go 1.21 and Delve 1.21.2

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -1,10 +1,10 @@
-ARG GOVERSION=1.20
+ARG GOVERSION=1.21
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION} as delve
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.20.1
+ARG DELVE_VERSION=1.21.2
 
 # Patch delve to make defaults for --check-go-version and --only-same-user
 # to be set at build time.  We must install patch(1) to apply the patch.

--- a/go/skaffold.yaml
+++ b/go/skaffold.yaml
@@ -62,12 +62,21 @@ profiles:
           docker:
             buildArgs:
               GOVERSION: '1.20'
+      - op: add
+        path: /build/artifacts/-
+        value:
+          image: go121app
+          context: test/goapp
+          docker:
+            buildArgs:
+              GOVERSION: 1.21
     deploy:
       kubectl:
         manifests:
           - test/k8s-test-go118.yaml
           - test/k8s-test-go119.yaml
           - test/k8s-test-go120.yaml
+          - test/k8s-test-go121.yaml
 
   # release: pushes images to production with :latest
   - name: release

--- a/go/test/k8s-test-go121.yaml
+++ b/go/test/k8s-test-go121.yaml
@@ -1,0 +1,89 @@
+# This test approximates `skaffold debug` for a go app.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go121pod
+  labels:
+    app: hello
+    protocol: dlv
+    runtime: go121
+spec:
+  containers:
+  - name: go121app
+    image: go121app
+    args:
+    - /dbg/go/bin/dlv
+    - exec
+    - --log
+    - --headless
+    - --continue
+    - --accept-multiclient
+    # listen on 0.0.0.0 as it is exposed as a service
+    - --listen=0.0.0.0:56286
+    - --api-version=2
+    - ./app
+    ports:
+    - containerPort: 8080
+    - containerPort: 56286
+      name: dlv
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  initContainers:
+  - image: skaffold-debug-go
+    name: install-go-support
+    resources: {}
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  volumes:
+  - emptyDir: {}
+    name: go-debugging-support
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-dlv-go121
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  - name: dlv
+    port: 56286
+    protocol: TCP
+  selector:
+    app: hello
+    protocol: dlv
+    runtime: go121
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connect-to-go121
+  labels:
+    project: container-debug-support
+    type: integration-test
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-go121
+        image: kubectl
+        command: [sh, -c, "while ! curl -s hello-dlv-go121:8080 2>/dev/null; do echo waiting for app; sleep 1; done"]
+      containers:
+      - name: dlv-to-go121
+        image: skaffold-debug-go
+        command: [sh, -c, '
+          (echo bt; echo exit -c) > init.txt;
+          set -x;
+          /duct-tape/go/bin/dlv connect --init init.txt hello-dlv-go121:56286']


### PR DESCRIPTION
This PR adds support for Go 1.21, following the changes made in #126.