### PR TITLE
Update Dockerfile, update getvsdbg to getvsdbgshbeta (working)

### DIFF
--- a/netcore/helper-image/Dockerfile
+++ b/netcore/helper-image/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 # assume glibc; RuntimeIDs gleaned from the getvsdbgsh script
 RUN RuntimeID=$(case "$TARGETPLATFORM" in linux/amd64) echo linux-x64;; linux/arm64) echo linux-arm64;; *) exit 1;; esac); \
- mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgsh | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
+ mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgshbeta | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
changing from broken  vs debug installer (https://aka.ms/getvsdbgsh) to the working on https://aka.ms/getvsdbgshbeta

The broken version has missing dependencies on alpine linux, and it crashes every single time, regardless of client platform. this fixes it for me. running vsdbg on alpine container after running getvsdbg script always fails. updating to the beta install script installs the correct dependencies and vsdbg works!