### PR TITLE
change netcore runtime in debug adapter from linux-x64 to linux-musl-x64

### DIFF
--- a/netcore/helper-image/Dockerfile
+++ b/netcore/helper-image/Dockerfile
@@ -2,8 +2,8 @@ FROM --platform=$BUILDPLATFORM curlimages/curl as netcore
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 # assume glibc; RuntimeIDs gleaned from the getvsdbgsh script
-RUN RuntimeID=$(case "$TARGETPLATFORM" in linux/amd64) echo linux-x64;; linux/arm64) echo linux-arm64;; *) exit 1;; esac); \
- mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgshbeta | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
+RUN RuntimeID=$(case "$TARGETPLATFORM" in linux/amd64) echo linux-musl-x64;; linux/arm64) echo linux-arm64;; *) exit 1;; esac); \
+ mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgsh | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger

--- a/netcore/helper-image/Dockerfile
+++ b/netcore/helper-image/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 # assume glibc; RuntimeIDs gleaned from the getvsdbgsh script
 RUN RuntimeID=$(case "$TARGETPLATFORM" in linux/amd64) echo linux-x64;; linux/arm64) echo linux-arm64;; *) exit 1;; esac); \
- mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgsh | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
+ mkdir $HOME/vsdbg && curl -sSL https://aka.ms/getvsdbgshbeta | sh /dev/stdin -v latest -l $HOME/vsdbg -r $RuntimeID
 
 # Now populate the duct-tape image with the language runtime debugging support files
 # The debian image is about 95MB bigger


### PR DESCRIPTION
the runtime id for alpine is: linux-musl-x64 (...here https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)
``` sh
# curl -sSL https://aka.ms/getvsdbgsh | sh /dev/stdin -v latest -l /dbg/netcore -r linux-musl-x64
```
when I run this on the pod i am trying to debug, it all magically starts working.

otherwise I always just get "Failed to start process".... (because cloudcode had installed the  linux-x64 runtime debugger incorrectly. 

