### PR TITLE
feat(go): upgrade delve to support go 1.25

### DIFF
--- a/go/helper-image/Dockerfile
+++ b/go/helper-image/Dockerfile
@@ -1,10 +1,10 @@
-ARG GOVERSION=1.24
+ARG GOVERSION=1.25
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION} AS delve
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG DELVE_VERSION=1.24.1
+ARG DELVE_VERSION=1.25.2
 
 # Patch delve to make defaults for --check-go-version and --only-same-user
 # to be set at build time.  We must install patch(1) to apply the patch.

--- a/go/skaffold.yaml
+++ b/go/skaffold.yaml
@@ -94,6 +94,14 @@ profiles:
           docker:
             buildArgs:
               GOVERSION: '1.24'
+      - op: add
+        path: /build/artifacts/-
+        value:
+          image: go125app
+          context: test/goapp
+          docker:
+            buildArgs:
+              GOVERSION: '1.25'
 
     deploy:
       kubectl:
@@ -105,6 +113,7 @@ profiles:
           - test/k8s-test-go122.yaml
           - test/k8s-test-go123.yaml
           - test/k8s-test-go124.yaml
+          - test/k8s-test-go125.yaml
 
   # release: pushes images to production with :latest
   - name: release

--- a/go/test/k8s-test-go125.yaml
+++ b/go/test/k8s-test-go125.yaml
@@ -1,0 +1,89 @@
+# This test approximates `skaffold debug` for a go app.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go125pod
+  labels:
+    app: hello
+    protocol: dlv
+    runtime: go125
+spec:
+  containers:
+  - name: go125app
+    image: go125app
+    args:
+    - /dbg/go/bin/dlv
+    - exec
+    - --log
+    - --headless
+    - --continue
+    - --accept-multiclient
+    # listen on 0.0.0.0 as it is exposed as a service
+    - --listen=0.0.0.0:56286
+    - --api-version=2
+    - ./app
+    ports:
+    - containerPort: 8080
+    - containerPort: 56286
+      name: dlv
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  initContainers:
+  - image: skaffold-debug-go
+    name: install-go-support
+    resources: {}
+    volumeMounts:
+    - mountPath: /dbg
+      name: go-debugging-support
+  volumes:
+  - emptyDir: {}
+    name: go-debugging-support
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-dlv-go125
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  - name: dlv
+    port: 56286
+    protocol: TCP
+  selector:
+    app: hello
+    protocol: dlv
+    runtime: go125
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connect-to-go125
+  labels:
+    project: container-debug-support
+    type: integration-test
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-go125
+        image: kubectl
+        command: [sh, -c, "while ! curl -s hello-dlv-go125:8080 2>/dev/null; do echo waiting for app; sleep 1; done"]
+      containers:
+      - name: dlv-to-go125
+        image: skaffold-debug-go
+        command: [sh, -c, '
+          (echo bt; echo exit -c) > init.txt;
+          set -x;
+          /duct-tape/go/bin/dlv connect --init init.txt hello-dlv-go125:56286']


### PR DESCRIPTION
This PR is applying the obvious changes to support the latest version of Delve and therefore go 1.25.  

Closes #146 